### PR TITLE
Let Maze Runner get the repeater api key

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       BUILDKITE_STEP_KEY:
       BITBAR_USERNAME:
       BITBAR_ACCESS_KEY:
+      MAZE_REPEATER_API_KEY:
       UNITY_VERSION:
     ports:
       - "9000-9499:9339"


### PR DESCRIPTION
## Goal

Let Maze Runner get the repeater api key, enabling trace requests to be forwarded to the dashboard.

## Testing

Manually triggered a build from this branch, setting the environment variable.  Confirmed the dashboard project now displays performance data.