### PR TITLE
add missing wait for trace step

### DIFF
--- a/features/persistence.feature
+++ b/features/persistence.feature
@@ -6,6 +6,7 @@ Feature: Trace persistence
   Scenario: Receive a persisted trace
     When I set the HTTP status code for the next requests to "408"
     And I run the game in the "PersistTrace" state
+    And I wait to receive a trace
     And I wait for requests to persist
     And I discard the oldest trace
     And I close the Unity app


### PR DESCRIPTION
## Goal

The persistence feature was missing a wait to recieve trace step, causing the test to occasionally fail.
