### PR TITLE
Switch to a DI architecture to make future complexity easier to manage

### DIFF
--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/IPhasedStartup.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/IPhasedStartup.cs
@@ -1,0 +1,43 @@
+﻿using UnityEngine;
+
+namespace BugsnagUnityPerformance
+{
+    /**
+     * Phased startup ensures that components can rely on the fact that other
+     * components are at a similar phase of startup when running certain kinds of code.
+     * 
+     * Each IPhasedStartup object is responsible for passing IPhasedStartup
+     * messages to sub-objects that it owns (ownership meaning that this is the
+     * object that actually instantiated the sub-object). If the IPhasedStartup
+     * object was passed in via a constructor, YOU DO NOT OWN IT.
+     * 
+     * It consists of the following phases:
+     * 
+     * 1. Construction
+     * 
+     * - Call only constructors to construct sub-objects and their dependents
+     *   (building the object graph but not calling it).
+     * Note: Do not call methods on other IPhasedStartup objects.
+     * 
+     * 2. Configuration
+     * 
+     * - Read the configuration and store relevant information that this object will require.
+     * - Get this object into a state where any of its public methods can be called without breaking.
+     * - Pass the Configure message to any IPhasedStartup objects owned by this object.
+     * Note: Do not call methods on other IPhasedStartup objects (other than Configure)
+     *       because we can't assume that any other objects have been configured yet.
+     * 
+     * 3. Start
+     * 
+     * - Start this component and any owned IPhasedStartup subobjects.
+     *   Most objects will do nothing here, but if you need to start threads,
+     *   register OS callbacks etc, this is the place to do it.
+     * - Pass the Start message to any IPhasedStartup objects owned by this object.
+     * Note: It's safe to call other IPhasedStartup objects.
+     */
+    interface IPhasedStartup
+    {
+        void Configure(PerformanceConfiguration config);
+        void Start();
+    }
+}

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/IPhasedStartup.cs.meta
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/IPhasedStartup.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ec58e222cb3134c46bb717a204dcc00d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Sampler.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Sampler.cs
@@ -1,0 +1,39 @@
+﻿using UnityEngine;
+
+namespace BugsnagUnityPerformance
+{
+    public class Sampler : MonoBehaviour
+    {
+        public double probability;
+
+        public bool Sampled(Span span)
+        {
+            double p = probability;
+            bool isSampled = IsSampled(span, GetUpperBound(p));
+            if (isSampled)
+            {
+                span.UpdateSamplingProbability(p);
+            }
+            return isSampled;
+        }
+
+        private bool IsSampled(Span span, uint upperBound)
+        {
+            uint traceId = uint.Parse(span.TraceId.Substring(0, 15), System.Globalization.NumberStyles.HexNumber);
+            return traceId <= upperBound;
+        }
+
+        private uint GetUpperBound(double p)
+        {
+            if (p <= 0)
+            {
+                return 0;
+            }
+            if (p >= 1.0)
+            {
+                return uint.MaxValue;
+            }
+            return (uint)(p * (double)uint.MaxValue);
+        }
+    }
+}

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Sampler.cs.meta
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Sampler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1a4af847102ea424d8305ee91f254e08
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/SpanFactory.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/SpanFactory.cs
@@ -12,23 +12,30 @@ namespace BugsnagUnityPerformance
         [ThreadStatic]
         private static Stack<ISpanContext> _contextStack;
 
-        private static RNGCryptoServiceProvider _rNGCryptoServiceProvider = new RNGCryptoServiceProvider();
+        private RNGCryptoServiceProvider _rNGCryptoServiceProvider = new RNGCryptoServiceProvider();
 
-        private static string GetNewTraceId()
+        private OnSpanEnd _onSpanEnd;
+
+        public SpanFactory(OnSpanEnd onSpanEnd)
+        {
+            _onSpanEnd = onSpanEnd;
+        }
+
+        private string GetNewTraceId()
         {
             byte[] byteArray = new byte[16];
             _rNGCryptoServiceProvider.GetBytes(byteArray);
             return ByteArrayToHex(byteArray);
         }
 
-        private static string GetNewSpanId()
+        private string GetNewSpanId()
         {
             byte[] byteArray = new byte[8];
             _rNGCryptoServiceProvider.GetBytes(byteArray);
             return ByteArrayToHex(byteArray);
         }
 
-        private static string ByteArrayToHex(byte[] barray)
+        private string ByteArrayToHex(byte[] barray)
         {
             char[] c = new char[barray.Length * 2];
             byte b;
@@ -42,14 +49,14 @@ namespace BugsnagUnityPerformance
             return new string(c);
         }
 
-        internal static Span StartCustomSpan(string name, SpanOptions spanOptions)
+        internal Span StartCustomSpan(string name, SpanOptions spanOptions)
         {
             // custom spans are always first class
             spanOptions.IsFirstClass = true;
             return CreateSpan(name,SpanKind.SPAN_KIND_INTERNAL, spanOptions);
         }
 
-        private static Span CreateSpan(string name, SpanKind kind, SpanOptions spanOptions)
+        private Span CreateSpan(string name, SpanKind kind, SpanOptions spanOptions)
         {
                         
             if (spanOptions.ParentContext != null)
@@ -72,7 +79,7 @@ namespace BugsnagUnityPerformance
                 traceId = GetNewTraceId();
             }
 
-            var newSpan = new Span(name, kind, spanId, traceId, parentSpanId, spanOptions.StartTime, spanOptions.IsFirstClass);
+            var newSpan = new Span(name, kind, spanId, traceId, parentSpanId, spanOptions.StartTime, spanOptions.IsFirstClass, _onSpanEnd);
 
             if (spanOptions.MakeCurrentContext)
             {
@@ -82,7 +89,7 @@ namespace BugsnagUnityPerformance
             return newSpan;
         }
 
-        internal static Span CreateAutomaticNetworkSpan(BugsnagUnityWebRequest request)
+        internal Span CreateAutomaticNetworkSpan(BugsnagUnityWebRequest request)
         {
             var verb = request.method.ToUpper();
 
@@ -99,7 +106,7 @@ namespace BugsnagUnityPerformance
         }
 
 
-        private static string GetConnectionType()
+        private string GetConnectionType()
         {
             switch (Application.internetReachability)
             {
@@ -114,7 +121,7 @@ namespace BugsnagUnityPerformance
             }
         }
 
-        internal static Span CreateAutomaticSceneLoadSpan()
+        internal Span CreateAutomaticSceneLoadSpan()
         {
             // Scene load spans are always first class
             var spanOptions = new SpanOptions { IsFirstClass = true };
@@ -122,7 +129,7 @@ namespace BugsnagUnityPerformance
             return span;
         }
 
-        private static ISpanContext GetCurrentContext()
+        private ISpanContext GetCurrentContext()
         {
             if (_contextStack != null && _contextStack.Count > 0)
             {
@@ -134,7 +141,7 @@ namespace BugsnagUnityPerformance
             }
         }
 
-        private static void AddToContextStack(ISpanContext spanContext)
+        private void AddToContextStack(ISpanContext spanContext)
         {
             if (_contextStack == null)
             {

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/TracePayload.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/TracePayload.cs
@@ -11,6 +11,7 @@ namespace BugsnagUnityPerformance
 
         public string PayloadId;
 
+        private ResourceModel _resourceModel;
         private List<SpanModel> _spans = new List<SpanModel>();
 
         // Temporary method to allow hard coding the Bugsnag-Span-Sampling header until sampling is properly implemented
@@ -18,8 +19,9 @@ namespace BugsnagUnityPerformance
 
         private string _jsonbody;
 
-        public TracePayload(List<Span> spans)
+        public TracePayload(ResourceModel resourceModel, List<Span> spans)
         {
+            _resourceModel = resourceModel;
             PayloadId = Guid.NewGuid().ToString();
             foreach (var span in spans)
             {
@@ -39,7 +41,7 @@ namespace BugsnagUnityPerformance
             if (string.IsNullOrEmpty(_jsonbody))
             {
                 var scopeSpans = new ScopeSpanModel[] { new ScopeSpanModel(_spans.ToArray()) };
-                var resourceSpans = new ResourceSpanModel[] { new ResourceSpanModel(scopeSpans) };
+                var resourceSpans = new ResourceSpanModel[] { new ResourceSpanModel(_resourceModel, scopeSpans) };
                 var serialiseablePayload = new TracePayloadBody()
                 {
                     resourceSpans = resourceSpans

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Models/ResourceModel.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Models/ResourceModel.cs
@@ -4,33 +4,28 @@ using UnityEngine;
 
 namespace BugsnagUnityPerformance
 {
-    internal class ResourceModel
+    internal class ResourceModel: IPhasedStartup
     {
-
-        private static List<AttributeModel> _resourceData;
+        private CacheManager _cacheManager;
 
         public List<AttributeModel> attributes;
 
-        public ResourceModel()
+        public ResourceModel(CacheManager cacheManager)
         {
-            attributes = GetResourceData();
+            _cacheManager = cacheManager;
         }
 
-        public static void InitResourceDataOnMainThread()
+        public void Configure(PerformanceConfiguration config)
         {
-            if (_resourceData == null)
-            {
-                _resourceData = new List<AttributeModel>
+            attributes = new List<AttributeModel>
                {
-                    new AttributeModel("deployment.environment", BugsnagPerformance.Configuration.ReleaseStage),
+                    new AttributeModel("deployment.environment", config.ReleaseStage),
 
                     new AttributeModel("telemetry.sdk.name", "bugsnag.performance.unity"),
 
                     new AttributeModel("telemetry.sdk.version", Version.VersionString),
 
                     new AttributeModel("os.version", Environment.OSVersion.VersionString),
-
-                    new AttributeModel("device.id", CacheManager.GetDeviceId()),
 
                     new AttributeModel("device.model.identifier", SystemInfo.deviceModel),
 
@@ -40,32 +35,31 @@ namespace BugsnagUnityPerformance
 
                     new AttributeModel("bugsnag.runtime_versions.unity", Application.unityVersion),
                };
-                var mobileBuildNumber = GetMobileBuildNumber();
-                if (mobileBuildNumber != null)
-                {
-                    _resourceData.Add(mobileBuildNumber);
-                }
+            var mobileBuildNumber = GetMobileBuildNumber();
+            if (mobileBuildNumber != null)
+            {
+                attributes.Add(mobileBuildNumber);
+            }
 
-                var mobileManufacturer = GetMobileManufacturer();
-                if (mobileManufacturer != null)
-                {
-                    _resourceData.Add(mobileManufacturer);
-                }
+            var mobileManufacturer = GetMobileManufacturer();
+            if (mobileManufacturer != null)
+            {
+                attributes.Add(mobileManufacturer);
+            }
 
-                var mobileArch = GetMobileArch();
-                if (mobileArch != null)
-                {
-                    _resourceData.Add(mobileArch);
-                }
+            var mobileArch = GetMobileArch();
+            if (mobileArch != null)
+            {
+                attributes.Add(mobileArch);
             }
         }
 
-        private static List<AttributeModel> GetResourceData()
+        public void Start()
         {
-            return _resourceData;
+            attributes.Add(new AttributeModel("device.id", _cacheManager.GetDeviceId()));
         }
 
-        private static string GetPlatform()
+        private string GetPlatform()
         {
             switch (Application.platform)
             {
@@ -77,7 +71,7 @@ namespace BugsnagUnityPerformance
             return string.Empty;
         }
 
-        private static AttributeModel GetMobileBuildNumber()
+        private AttributeModel GetMobileBuildNumber()
         {
 #if UNITY_EDITOR
             return null;
@@ -88,7 +82,7 @@ namespace BugsnagUnityPerformance
 #endif
         }
 
-        private static AttributeModel GetMobileArch()
+        private AttributeModel GetMobileArch()
         {
 #if UNITY_EDITOR
             return null;
@@ -99,7 +93,7 @@ namespace BugsnagUnityPerformance
 #endif
         }
 
-        private static AttributeModel GetMobileManufacturer()
+        private AttributeModel GetMobileManufacturer()
         {
 #if UNITY_EDITOR
             return null;
@@ -109,7 +103,5 @@ namespace BugsnagUnityPerformance
             return new AttributeModel("device.manufacturer", AndroidNative.GetManufacture());
 #endif
         }
-
-
     }
 }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Models/ResourceSpanModel.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Models/ResourceSpanModel.cs
@@ -8,9 +8,9 @@ namespace BugsnagUnityPerformance
 
         public ResourceModel resource;
 
-        public ResourceSpanModel(ScopeSpanModel[] scopeSpans)
+        public ResourceSpanModel(ResourceModel resourceModel, ScopeSpanModel[] scopeSpans)
         {
-            this.resource = new ResourceModel();
+            this.resource = resourceModel;
             this.scopeSpans = scopeSpans;
         }
     }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
@@ -7,9 +7,9 @@ namespace BugsnagUnityPerformance
 
         //Internal config
 
-        internal static int MaxBatchSize = 100;
-        internal static float MaxBatchAgeSeconds = 30f;
-        internal static int MaxPersistedBatchAgeSeconds = 86400; //24 hours
+        internal int MaxBatchSize = 100;
+        internal float MaxBatchAgeSeconds = 30f;
+        internal int MaxPersistedBatchAgeSeconds = 86400; //24 hours
 
         //Public config
 

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenario.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenario.cs
@@ -42,19 +42,19 @@ public class Scenario : MonoBehaviour
 
     public void SetMaxBatchSize(int size)
     {
-        var fieldInfo = typeof(PerformanceConfiguration).GetField("MaxBatchSize", BindingFlags.Static | BindingFlags.NonPublic);
+        var fieldInfo = typeof(PerformanceConfiguration).GetField("MaxBatchSize", BindingFlags.Instance | BindingFlags.NonPublic);
         fieldInfo.SetValue(Configuration, size);
     }
 
     public void SetMaxPersistedBatchAgeSeconds(int seconds)
     {
-        var fieldInfo = typeof(PerformanceConfiguration).GetField("MaxPersistedBatchAgeSeconds", BindingFlags.Static | BindingFlags.NonPublic);
+        var fieldInfo = typeof(PerformanceConfiguration).GetField("MaxPersistedBatchAgeSeconds", BindingFlags.Instance | BindingFlags.NonPublic);
         fieldInfo.SetValue(Configuration, seconds);
     }
 
     public void SetMaxBatchAgeSeconds(float seconds)
     {
-        var fieldInfo = typeof(PerformanceConfiguration).GetField("MaxBatchAgeSeconds", BindingFlags.Static | BindingFlags.NonPublic);
+        var fieldInfo = typeof(PerformanceConfiguration).GetField("MaxBatchAgeSeconds", BindingFlags.Instance | BindingFlags.NonPublic);
         fieldInfo.SetValue(Configuration, seconds);
     }
 


### PR DESCRIPTION
## Goal

The existing approach of static methods is about to become cumbersome as we move to more complex objects and callback mechanisms. Switch to a DI architecture to make this transition easier.

## Testing

The external API remains unchanged, so all tests must run unmodified.
