### PR TITLE
Add basic sampling support

### DIFF
--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/CacheManager.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/CacheManager.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace BugsnagUnityPerformance
 {
-    internal class CacheManager: IPhasedStartup
+    public class CacheManager: IPhasedStartup
     {
         private int _maxPersistedBatchAgeSeconds;
         private string _cacheDirectory;

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Sampler.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Sampler.cs
@@ -2,14 +2,24 @@
 
 namespace BugsnagUnityPerformance
 {
-    public class Sampler : MonoBehaviour
+    public class Sampler : IPhasedStartup
     {
         public double probability;
 
+        public void Configure(PerformanceConfiguration config)
+        {
+            probability = config.SamplingProbability;
+        }
+
+        public void Start()
+        {
+            // Nothing to do
+        }
+
         public bool Sampled(Span span)
         {
-            double p = probability;
-            bool isSampled = IsSampled(span, GetUpperBound(p));
+            var p = probability;
+            var isSampled = IsSampled(span, GetUpperBound(p));
             if (isSampled)
             {
                 span.UpdateSamplingProbability(p);
@@ -17,13 +27,13 @@ namespace BugsnagUnityPerformance
             return isSampled;
         }
 
-        private bool IsSampled(Span span, uint upperBound)
+        private bool IsSampled(Span span, ulong upperBound)
         {
-            uint traceId = uint.Parse(span.TraceId.Substring(0, 15), System.Globalization.NumberStyles.HexNumber);
+            var traceId = ulong.Parse(span.TraceId.Substring(0, 16), System.Globalization.NumberStyles.HexNumber);
             return traceId <= upperBound;
         }
 
-        private uint GetUpperBound(double p)
+        private ulong GetUpperBound(double p)
         {
             if (p <= 0)
             {
@@ -31,9 +41,9 @@ namespace BugsnagUnityPerformance
             }
             if (p >= 1.0)
             {
-                return uint.MaxValue;
+                return ulong.MaxValue;
             }
-            return (uint)(p * (double)uint.MaxValue);
+            return (ulong)(p * (double)ulong.MaxValue);
         }
     }
 }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/TracePayload.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/TracePayload.cs
@@ -6,10 +6,11 @@ using UnityEngine;
 
 namespace BugsnagUnityPerformance
 {
-    internal class TracePayload
+    public class TracePayload
     {
 
         public string PayloadId;
+        public SortedList<double, int> SamplingHistogram { get;  private set; }
 
         private ResourceModel _resourceModel;
         private List<SpanModel> _spans = new List<SpanModel>();
@@ -28,12 +29,31 @@ namespace BugsnagUnityPerformance
                 _spans.Add(new SpanModel(span));
             }
             BatchSize = spans.Count;
+            SamplingHistogram = CalculateSamplingHistorgram(spans);
         }
 
         public TracePayload(string cachedJson, string payloadId)
         {
             PayloadId = payloadId;
             _jsonbody = cachedJson;
+        }
+
+        private static SortedList<double, int> CalculateSamplingHistorgram(List<Span> spans)
+        {
+            var histogram = new Dictionary<double, int>();
+            foreach (Span span in spans)
+            {
+                var p = span.samplingProbability;
+                if (histogram.ContainsKey(p))
+                {
+                    histogram[p]++;
+                }
+                else
+                {
+                    histogram[p] = 1;
+                }
+            }
+            return new SortedList<double, int>(histogram);
         }
 
         public string GetJsonBody()

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Tracer.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Tracer.cs
@@ -20,10 +20,13 @@ namespace BugsnagUnityPerformance
 
         private DateTimeOffset _lastBatchSendTime = DateTimeOffset.UtcNow;
 
+        private Sampler _sampler;
+
         private Delivery _delivery;
 
-        public Tracer(Delivery delivery)
+        public Tracer(Sampler sampler, Delivery delivery)
         {
+            _sampler = sampler;
             _delivery = delivery;
         }
 
@@ -64,8 +67,10 @@ namespace BugsnagUnityPerformance
 
         public void OnSpanEnd(Span span)
         {
-            //TODO check sampling logic to see if span should be ignored
-            AddSpanToQueue(span);
+            if (_sampler.Sampled(span))
+            {
+                AddSpanToQueue(span);
+            }
         }
 
         private void AddSpanToQueue(Span span)

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Models/AttributeModel.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Models/AttributeModel.cs
@@ -1,7 +1,7 @@
 ﻿namespace BugsnagUnityPerformance
 {
 
-    internal class AttributeModel
+    public class AttributeModel
     {
         public string key;
 

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Models/ResourceModel.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Models/ResourceModel.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace BugsnagUnityPerformance
 {
-    internal class ResourceModel: IPhasedStartup
+    public class ResourceModel: IPhasedStartup
     {
         private CacheManager _cacheManager;
 

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformance.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformance.cs
@@ -50,6 +50,7 @@ namespace BugsnagUnityPerformance
         private CacheManager _cacheManager;
         private Delivery _delivery;
         private ResourceModel _resourceModel;
+        private Sampler _sampler = new Sampler();
         private Tracer _tracer;
 
         private Dictionary<BugsnagUnityWebRequest, Span> _networkSpans = new Dictionary<BugsnagUnityWebRequest, Span>();
@@ -62,7 +63,7 @@ namespace BugsnagUnityPerformance
             _cacheManager = new CacheManager(Application.persistentDataPath);
             _resourceModel = new ResourceModel(_cacheManager);
             _delivery = new Delivery(_resourceModel, _cacheManager);
-            _tracer = new Tracer(_delivery);
+            _tracer = new Tracer(_sampler, _delivery);
             _spanFactory = new SpanFactory(OnSpanEnd);
         }
 
@@ -77,6 +78,7 @@ namespace BugsnagUnityPerformance
             _cacheManager.Configure(config);
             _delivery.Configure(config);
             _resourceModel.Configure(config);
+            _sampler.Configure(config);
             _tracer.Configure(config);
         }
 
@@ -85,6 +87,7 @@ namespace BugsnagUnityPerformance
             _cacheManager.Start();
             _delivery.Start();
             _resourceModel.Start();
+            _sampler.Start();
             _tracer.Start();
 
             SetupNetworkListener();

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
@@ -38,6 +38,8 @@ namespace BugsnagUnityPerformance
 
         public string ReleaseStage = Debug.isDebugBuild ? "development" : "production";
 
+        public double SamplingProbability = 1.0;
+
         public PerformanceConfiguration(string apiKey)
         {
             ApiKey = apiKey;

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/Span.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/Span.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace BugsnagUnityPerformance
 {
-    delegate void OnSpanEnd(Span span);
+    public delegate void OnSpanEnd(Span span);
 
     public class Span : ISpanContext
     {
@@ -23,7 +23,7 @@ namespace BugsnagUnityPerformance
         private object _endLock = new object();
         private OnSpanEnd _onSpanEnd;
 
-        internal Span(string name, SpanKind kind, string id, string traceId, string parentSpanId, DateTimeOffset startTime, bool? isFirstClass, OnSpanEnd onSpanEnd)
+        public Span(string name, SpanKind kind, string id, string traceId, string parentSpanId, DateTimeOffset startTime, bool? isFirstClass, OnSpanEnd onSpanEnd)
         {
             Name = name;
             Kind = kind;
@@ -103,7 +103,7 @@ namespace BugsnagUnityPerformance
             _onSpanEnd(this);
         }
 
-        internal void UpdateSamplingProbability(double value)
+        public void UpdateSamplingProbability(double value)
         {
             if (samplingProbability > value)
             {

--- a/BugsnagPerformance/Assets/UnitTests/SamplerTests.cs
+++ b/BugsnagPerformance/Assets/UnitTests/SamplerTests.cs
@@ -1,0 +1,161 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using BugsnagUnityPerformance;
+using System;
+
+namespace Tests
+{
+    public class SamplerTests
+    {
+        private const string VALID_API_KEY = "227df1042bc7772c321dbde3b31a03c2";
+
+        private void OnSpanEnd(Span span)
+        {
+            // Nothing to do
+        }
+
+        [Test]
+        public void TestDefaultConfig()
+        {
+            var sampler = new Sampler();
+
+            var span = new Span("test",
+                SpanKind.SPAN_KIND_INTERNAL,
+                "f000000000000000",
+                "f0000000000000000000000000000000",
+                "",
+                DateTimeOffset.Now,
+                true,
+                OnSpanEnd);
+
+            var config = new PerformanceConfiguration(VALID_API_KEY);
+            sampler.Configure(config);
+            sampler.Start();
+
+            Assert.IsTrue(sampler.Sampled(span));
+        }
+
+        [Test]
+        public void TestProbability1_0()
+        {
+            var sampler = new Sampler();
+
+            var span = new Span("test",
+                SpanKind.SPAN_KIND_INTERNAL,
+                "f000000000000000",
+                "f0000000000000000000000000000000",
+                "",
+                DateTimeOffset.Now,
+                true,
+                OnSpanEnd);
+
+            var config = new PerformanceConfiguration(VALID_API_KEY);
+            config.SamplingProbability = 1.0;
+            sampler.Configure(config);
+            sampler.Start();
+
+            Assert.IsTrue(sampler.Sampled(span));
+        }
+
+        [Test]
+        public void TestProbability0_0()
+        {
+            var sampler = new Sampler();
+
+            var span = new Span("test",
+                SpanKind.SPAN_KIND_INTERNAL,
+                "1000000000000000",
+                "10000000000000000000000000000000",
+                "",
+                DateTimeOffset.Now,
+                true,
+                OnSpanEnd);
+
+            var config = new PerformanceConfiguration(VALID_API_KEY);
+            config.SamplingProbability = 0.0;
+            sampler.Configure(config);
+            sampler.Start();
+
+            Assert.IsFalse(sampler.Sampled(span));
+        }
+
+        [Test]
+        public void TestProbability0_1()
+        {
+            var sampler = new Sampler();
+
+            var span = new Span("test",
+                SpanKind.SPAN_KIND_INTERNAL,
+                "1000000000000000",
+                "f0000000000000000000000000000000",
+                "",
+                DateTimeOffset.Now,
+                true,
+                OnSpanEnd);
+
+            var config = new PerformanceConfiguration(VALID_API_KEY);
+            config.SamplingProbability = 0.1;
+            sampler.Configure(config);
+            sampler.Start();
+
+            Assert.IsFalse(sampler.Sampled(span));
+
+            span = new Span("test",
+                SpanKind.SPAN_KIND_INTERNAL,
+                "1000000000000000",
+                "10000000000000000000000000000000",
+                "",
+                DateTimeOffset.Now,
+                true,
+                OnSpanEnd);
+            Assert.IsTrue(sampler.Sampled(span));
+
+        }
+
+        [Test]
+        public void TestProbability0_9()
+        {
+            var sampler = new Sampler();
+
+            var span = new Span("test",
+                SpanKind.SPAN_KIND_INTERNAL,
+                "1000000000000000",
+                "c0000000000000000000000000000000",
+                "",
+                DateTimeOffset.Now,
+                true,
+                OnSpanEnd);
+
+            var config = new PerformanceConfiguration(VALID_API_KEY);
+            config.SamplingProbability = 0.9;
+            sampler.Configure(config);
+            sampler.Start();
+
+            Assert.IsTrue(sampler.Sampled(span));
+
+            span = new Span("test",
+                SpanKind.SPAN_KIND_INTERNAL,
+                "1000000000000000",
+                "10000000000000000000000000000000",
+                "",
+                DateTimeOffset.Now,
+                true,
+                OnSpanEnd);
+            Assert.IsTrue(sampler.Sampled(span));
+
+            span = new Span("test",
+                SpanKind.SPAN_KIND_INTERNAL,
+                "1000000000000000",
+                "ffffffffffffffffffffffffffffffff",
+                "",
+                DateTimeOffset.Now,
+                true,
+                OnSpanEnd);
+            Assert.IsFalse(sampler.Sampled(span));
+
+        }
+    }
+}

--- a/BugsnagPerformance/Assets/UnitTests/SamplerTests.cs.meta
+++ b/BugsnagPerformance/Assets/UnitTests/SamplerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fa830e91607ac42e7bbfc23ff04b5c12
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/BugsnagPerformance/Assets/UnitTests/TracePayloadTests.cs
+++ b/BugsnagPerformance/Assets/UnitTests/TracePayloadTests.cs
@@ -1,0 +1,87 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using BugsnagUnityPerformance;
+using System;
+
+namespace Tests
+{
+    public class TracePayloadTests
+    {
+        [Test]
+        public void TestHistogram()
+        {
+            AssertSpanSamplingHistogram(
+                new List<double> { },
+                new SortedList<double, int> {
+                });
+
+
+            AssertSpanSamplingHistogram(
+                new List<double> { 1.0 },
+                new SortedList<double, int> {
+                    { 1.0, 1 }
+                });
+
+            AssertSpanSamplingHistogram(
+                new List<double> { 1.0, 1.0 },
+                new SortedList<double, int> {
+                    { 1.0, 2 }
+                });
+
+            AssertSpanSamplingHistogram(
+                new List<double> { 1.0, 0.5, 1.0 },
+                new SortedList<double, int> {
+                    { 0.5, 1 },
+                    { 1.0, 2 }
+                });
+
+            AssertSpanSamplingHistogram(
+                new List<double> { 1.0, 0.1, 0.5, 1.0, 0.5, 0.2, 1.0, 0.5 },
+                new SortedList<double, int> {
+                    { 0.1, 1 },
+                    { 0.2, 1 },
+                    { 0.5, 3 },
+                    { 1.0, 3 }
+                });
+        }
+
+        private void AssertSpanSamplingHistogram(List<double> pValues, SortedList<double, int> expectedHistogram)
+        {
+            var cacheManager = new CacheManager(Application.temporaryCachePath);
+            var resourceModel = new ResourceModel(cacheManager);
+            var payload = new TracePayload(resourceModel, SpansWithProbabilities(pValues));
+            Assert.AreEqual(expectedHistogram, payload.SamplingHistogram);
+        }
+
+        private List<Span> SpansWithProbabilities(List<double> pValues)
+        {
+            var result = new List<Span>();
+            foreach (double p in pValues)
+            {
+                result.Add(SpanWithProbability(p));
+            }
+            return result;
+        }
+        private Span SpanWithProbability(double probability)
+        {
+            var span = new Span("test",
+                            SpanKind.SPAN_KIND_INTERNAL,
+                            "f000000000000000",
+                            "00000000000000010000000000000000",
+                            "",
+                            DateTimeOffset.Now,
+                            true,
+                            OnSpanEnd);
+            span.UpdateSamplingProbability(probability);
+            return span;
+        }
+
+        private void OnSpanEnd(Span span)
+        {
+            // Nothing to do
+        }
+    }
+}

--- a/BugsnagPerformance/Assets/UnitTests/TracePayloadTests.cs.meta
+++ b/BugsnagPerformance/Assets/UnitTests/TracePayloadTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1ac1117e80ece46e789f453daab595cb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'rake'
 
 unless Gem.win_platform?
   # Use official Maze Runner release
-  gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v7.14.0'
+  gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v7.27.0'
 
   # Use a specific Maze Runner branch
   #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'master'

--- a/features/fixtures/mazerunner/Assets/Scenes/MainScene.unity
+++ b/features/fixtures/mazerunner/Assets/Scenes/MainScene.unity
@@ -571,6 +571,62 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0aa183120c39b4c66ab7937b70a90ddd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &805103369
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 805103370}
+  - component: {fileID: 805103372}
+  - component: {fileID: 805103371}
+  m_Layer: 0
+  m_Name: Sampling
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &805103370
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 805103369}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1294582014}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &805103371
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 805103369}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a32a96bf322a94f70b7ba035af268aa3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &805103372
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 805103369}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ba12eb576362843c294f2c112710fc5d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &895329258
 GameObject:
   m_ObjectHideFlags: 0
@@ -648,6 +704,7 @@ Transform:
   - {fileID: 2146169737}
   - {fileID: 480052158}
   - {fileID: 1609554505}
+  - {fileID: 805103370}
   m_Father: {fileID: 2126837007}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Spans/ConfiguredSamplingRate0.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Spans/ConfiguredSamplingRate0.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using BugsnagUnityPerformance;
+using UnityEngine;
+
+public class ConfiguredSamplingRate0 : Scenario
+{
+
+    private Span _span;
+
+    public override void PrepareConfig(string apiKey, string host)
+    {
+        base.PrepareConfig(apiKey, host);
+        Configuration.SamplingProbability = 0;
+        SetMaxBatchAgeSeconds(1);
+    }
+
+    public override void Run()
+    {
+        base.Run();
+        _span = BugsnagPerformance.StartSpan("ManualSpan");
+        Invoke("EndSpan", 1);
+    }
+
+    private void EndSpan()
+    {
+        _span.End();
+    }
+}

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Spans/ConfiguredSamplingRate0.cs.meta
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Spans/ConfiguredSamplingRate0.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ba12eb576362843c294f2c112710fc5d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Spans/ConfiguredSamplingRate1.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Spans/ConfiguredSamplingRate1.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using BugsnagUnityPerformance;
+using UnityEngine;
+
+public class ConfiguredSamplingRate1 : Scenario
+{
+    public override void PrepareConfig(string apiKey, string host)
+    {
+        base.PrepareConfig(apiKey, host);
+        Configuration.SamplingProbability = 1;
+        SetMaxBatchAgeSeconds(1);
+    }
+
+    public override void Run()
+    {
+        base.Run();
+        BugsnagPerformance.StartSpan("ManualSpan1").End();
+        BugsnagPerformance.StartSpan("ManualSpan2").End();
+        BugsnagPerformance.StartSpan("ManualSpan3").End();
+        BugsnagPerformance.StartSpan("ManualSpan4").End();
+    }
+}

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Spans/ConfiguredSamplingRate1.cs.meta
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Spans/ConfiguredSamplingRate1.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a32a96bf322a94f70b7ba035af268aa3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/sampling.feature
+++ b/features/sampling.feature
@@ -1,0 +1,23 @@
+Feature: Sampling spans
+
+  Background:
+    Given I clear the Bugsnag cache
+
+  Scenario: With probability 1, all spans are sampled
+    When I run the game in the "ConfiguredSamplingRate1" state
+    And I wait for 4 spans
+    Then the trace Bugsnag-Integrity header is valid
+    And the trace "Bugsnag-Api-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+    And the trace "Bugsnag-Span-Sampling" header equals "1:4"
+    * a span name equals "ManualSpan1"
+    * a span name equals "ManualSpan2"
+    * a span name equals "ManualSpan3"
+    * a span name equals "ManualSpan4"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"    
+
+  Scenario: With probability 0, no spans are sampled
+    When I run the game in the "ConfiguredSamplingRate0" state
+    Then I should receive no traces


### PR DESCRIPTION
## Goal

This PR adds span sampling. For now, sampling is controlled solely through the configuration. More advanced control will be added in a later PR.

Caveats:

* The sampling histogram `Bugsnag-Span-Sampling` is only created for fresh payloads for now. Supporting it on persisted payloads will require a change to the on-disk format, which will happen in a later PR.
* Some classes have been made public so that they can be unit tested.

## Testing

* Added unit tests for sampling and histogram generation.
* Added e2e tests for sampling and histogram.
