### PR TITLE
add header and discard oversized failed payloads

### DIFF
--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Delivery.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Delivery.cs
@@ -101,7 +101,7 @@ namespace BugsnagUnityPerformance
                 else if (code == 0 || code == 408 || code == 429 || code >= 500)
                 {
                     // sending failed with retryable error, cache for later retry
-                    if (body.Length < MAX_PAYLOAD_BYTES)
+                    if (body.Length <= MAX_PAYLOAD_BYTES)
                     {
                         _cacheManager.CacheBatch(payload);
                     }


### PR DESCRIPTION
## Goal

Add the following basic handling for oversized payloads, pending a more sophisticated approach once we have more data points:

- Remove all payloads that fail due to a terminated connection if they are oversized (we cannot determine the response code for these)

- Use the uncompressed size when calculating the 1mb limit

- Add Bugsnag-Uncompressed-Content-Length to communicate size to server for improved handling in future


## Testing

Manually tested the header