### PR TITLE
docs(readme): branding updates

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Bugsnag
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-# bugsnag-unity-performance
+<div align="center">
+  <a href="https://www.bugsnag.com/platforms/unity">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://assets.smartbear.com/m/3dab7e6cf880aa2b/original/BugSnag-Repository-Header-Dark.svg">
+      <img alt="SmartBear BugSnag logo" src="https://assets.smartbear.com/m/3945e02cdc983893/original/BugSnag-Repository-Header-Light.svg">
+    </picture>
+  </a>
+  <h1>Performance monitoring for Unity</h1>
+</div>
+
+[![Documentation](https://img.shields.io/badge/documentation-latest-blue.svg)](https://docs.bugsnag.com/performance/unity/)
+[![Build status](https://badge.buildkite.com/7d0c92f58cf5e7fca4d3efc3aecf414ce10cdb010b7ec81688.svg?branch=main)](https://buildkite.com/bugsnag/bugsnag-unity-performance)
+
+Monitor the start-up, scene loading and network requests of your game and see the results in your [BugSnag](https://www.bugsnag.com) dashboard.
+
+## Features
+
+- Automatic measurement of app start-up
+- Wrapper for recording scene load durations
+- Wrapper for `UnityWebRequest` requests
+
+## Getting started
+
+For integration instructions, see our online docs: [docs.bugsnag.com/performance/unity](https://docs.bugsnag.com/performance/unity)
+
+## Support
+
+* [Read the integration guide](https://docs.bugsnag.com/performance/unity/)
+* [Search open and closed issues](https://github.com/bugsnag/bugsnag-unity-performance/issues?utf8=✓&q=is%3Aissue) for similar problems
+* [Report a bug or request a feature](https://github.com/bugsnag/bugsnag-unity-performance/issues/new)
+
+## License
+
+The BugSnag Unity Performance SDK is free software released under the MIT License. See the [LICENSE](./LICENSE) for details.


### PR DESCRIPTION
## Goal

Added standard branding for BugSnag repo plus the license file, ahead of GA release.