### PR TITLE
PLAT-10287 change sampling config to internal

### DIFF
--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
@@ -12,6 +12,7 @@ namespace BugsnagUnityPerformance
         internal int MaxPersistedBatchAgeSeconds = 86400; //24 hours
         internal float PValueTimeoutSeconds = 86400f;
         internal float PValueCheckIntervalSeconds = 30f;
+        internal double SamplingProbability = 1.0;
 
         //Public config
 
@@ -41,8 +42,6 @@ namespace BugsnagUnityPerformance
         public string Endpoint = "https://otlp.bugsnag.com/v1/traces";
 
         public string ReleaseStage = Debug.isDebugBuild ? "development" : "production";
-
-        public double SamplingProbability = 1.0;
 
         public PerformanceConfiguration(string apiKey)
         {

--- a/BugsnagPerformance/Assets/UnitTests/SamplerTests.cs
+++ b/BugsnagPerformance/Assets/UnitTests/SamplerTests.cs
@@ -4,6 +4,7 @@ using BugsnagUnityPerformance;
 using System;
 using System.IO;
 using System.Text;
+using System.Reflection;
 
 namespace Tests
 {
@@ -57,16 +58,6 @@ namespace Tests
         }
 
         [Test]
-        public void TestCustomConfig()
-        {
-            var config = new PerformanceConfiguration(VALID_API_KEY);
-            config.SamplingProbability = 0.1;
-            var sampler = NewSampler(config, true);
-
-            Assert.AreEqual(0.1, sampler.Probability);
-        }
-
-        [Test]
         public void TestPersistence()
         {
             var config = new PerformanceConfiguration(VALID_API_KEY);
@@ -89,7 +80,6 @@ namespace Tests
         public void TestProbability1_0()
         {
             var config = new PerformanceConfiguration(VALID_API_KEY);
-            config.SamplingProbability = 1.0;
             var sampler = NewSampler(config, true);
 
             var span = new Span("test",
@@ -108,7 +98,7 @@ namespace Tests
         public void TestProbability0_0()
         {
             var config = new PerformanceConfiguration(VALID_API_KEY);
-            config.SamplingProbability = 0.0;
+            SetSamplingProbability(config, 0.0);
             var sampler = NewSampler(config, true);
 
             var span = new Span("test",
@@ -127,7 +117,7 @@ namespace Tests
         public void TestProbability0_1()
         {
             var config = new PerformanceConfiguration(VALID_API_KEY);
-            config.SamplingProbability = 0.1;
+            SetSamplingProbability(config, 0.1);
             var sampler = NewSampler(config, true);
 
             var span = new Span("test",
@@ -157,7 +147,7 @@ namespace Tests
         public void TestProbability0_9()
         {
             var config = new PerformanceConfiguration(VALID_API_KEY);
-            config.SamplingProbability = 0.9;
+            SetSamplingProbability(config, 0.9);
             var sampler = NewSampler(config, true);
 
             var span = new Span("test",
@@ -191,6 +181,12 @@ namespace Tests
                 OnSpanEnd);
             Assert.IsFalse(sampler.Sampled(span));
 
+        }
+
+        private void SetSamplingProbability(PerformanceConfiguration configuration, double p)
+        {
+            var fieldInfo = typeof(PerformanceConfiguration).GetField("SamplingProbability", BindingFlags.Instance | BindingFlags.NonPublic);
+            fieldInfo.SetValue(configuration, p);
         }
     }
 }

--- a/BugsnagPerformance/ProjectSettings/ProjectSettings.asset
+++ b/BugsnagPerformance/ProjectSettings/ProjectSettings.asset
@@ -682,7 +682,11 @@ PlayerSettings:
   webGLLinkerTarget: 1
   webGLThreadsSupport: 0
   webGLWasmStreaming: 0
-  scriptingDefineSymbols: {}
+  scriptingDefineSymbols:
+    1: BUGSNAG_PERFORMANCE
+    4: BUGSNAG_PERFORMANCE
+    7: BUGSNAG_PERFORMANCE
+    13: BUGSNAG_PERFORMANCE
   platformArchitecture: {}
   scriptingBackend: {}
   il2cppCompilerConfiguration: {}

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenario.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenario.cs
@@ -71,4 +71,10 @@ public class Scenario : MonoBehaviour
         fieldInfo.SetValue(Configuration, seconds);
     }
 
+    public void SetSamplingProbability(double p)
+    {
+        var fieldInfo = typeof(PerformanceConfiguration).GetField("SamplingProbability", BindingFlags.Instance | BindingFlags.NonPublic);
+        fieldInfo.SetValue(Configuration, p);
+    }
+
 }

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Persistence/PValueUpdate.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Persistence/PValueUpdate.cs
@@ -9,7 +9,6 @@ public class PValueUpdate : Scenario
     public override void PrepareConfig(string apiKey, string host)
     {
         base.PrepareConfig(apiKey, host);
-        Configuration.SamplingProbability = 1;
         SetMaxBatchAgeSeconds(1);
     }
 

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Spans/ConfiguredSamplingRate0.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Spans/ConfiguredSamplingRate0.cs
@@ -11,7 +11,7 @@ public class ConfiguredSamplingRate0 : Scenario
     public override void PrepareConfig(string apiKey, string host)
     {
         base.PrepareConfig(apiKey, host);
-        Configuration.SamplingProbability = 0;
+        SetSamplingProbability(0);
         SetMaxBatchAgeSeconds(1);
     }
 

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Spans/ConfiguredSamplingRate1.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Spans/ConfiguredSamplingRate1.cs
@@ -8,7 +8,6 @@ public class ConfiguredSamplingRate1 : Scenario
     public override void PrepareConfig(string apiKey, string host)
     {
         base.PrepareConfig(apiKey, host);
-        Configuration.SamplingProbability = 1;
         SetMaxBatchAgeSeconds(1);
     }
 

--- a/features/fixtures/mazerunner/ProjectSettings/ProjectSettings.asset
+++ b/features/fixtures/mazerunner/ProjectSettings/ProjectSettings.asset
@@ -684,7 +684,11 @@ PlayerSettings:
   webGLLinkerTarget: 1
   webGLThreadsSupport: 0
   webGLWasmStreaming: 0
-  scriptingDefineSymbols: {}
+  scriptingDefineSymbols:
+    1: BUGSNAG_PERFORMANCE
+    4: BUGSNAG_PERFORMANCE
+    7: BUGSNAG_PERFORMANCE
+    13: BUGSNAG_PERFORMANCE
   platformArchitecture: {}
   scriptingBackend: {}
   il2cppCompilerConfiguration: {}


### PR DESCRIPTION
## Goal

change sampling config to internal

## Changeset

- changed config.SamplingProbability to internal
- converted unit tests to access it through reflection
- converted e2e tests to access it through reflection
- commited the automaticly generated BUGSNAG_PERFORMANCE scripting symbols to save making git dirty in future. These are generated by the changes made in #42 and i forgot to commit them then. They do not get useed by anything yet and so i concider them harmless.


## Testing

covered by existing tests