### PR TITLE
handle empty enabledReleaseStages in config window

### DIFF
--- a/BugsnagPerformance/Assets/BugsnagPerformance/Editor/BugsnagPerformanceEditor.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Editor/BugsnagPerformanceEditor.cs
@@ -17,6 +17,11 @@ public class BugsnagPerformanceEditor : EditorWindow
         titleContent.text = "BugSnag Performance";
     }
 
+    private void Update()
+    {
+        CheckForSettingsCreation();
+    }
+
     private static string GetFullSettingsPath()
     {
         return Application.dataPath + "/Resources/Bugsnag/BugsnagPerformanceSettingsObject.asset";

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformanceSettingsObject.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformanceSettingsObject.cs
@@ -73,7 +73,10 @@ namespace BugsnagUnityPerformance
             {
                 config.ReleaseStage = ReleaseStage;
             }
-            config.EnabledReleaseStages = EnabledReleaseStages;
+            if (EnabledReleaseStages != null && EnabledReleaseStages.Length > 0)
+            {
+                config.EnabledReleaseStages = EnabledReleaseStages;
+            }
             config.AppVersion = AppVersion;
             config.BundleVersion = BundleVersion;
             config.VersionCode = VersionCode;


### PR DESCRIPTION
## Goal

When using the config window, if EnabledReleaseStages is empty then it will be ignored.

Also, fix issue where the window would go blank if the settings object was deleted while the window is open.

