### PR TITLE
fix guid errors and add public documentation

### DIFF
--- a/upm/upm-resources/README.md
+++ b/upm/upm-resources/README.md
@@ -14,4 +14,4 @@ The source code for this project is located at: https://github.com/bugsnag/bugsn
 
 ## Resources
 
-* [Documentation](https://docs.bugsnag.com/platforms/unity/)
+* [Documentation](https://docs.bugsnag.com/performance/unity/)

--- a/upm/upm-resources/README.md.meta
+++ b/upm/upm-resources/README.md.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4fd1b21ee993147aa8bb65ddadab8c4a
+guid: 02df0f971a3ca490d84c5bd2dddfe4f5
 TextScriptImporter:
   externalObjects: {}
   userData: 

--- a/upm/upm-resources/package.json.meta
+++ b/upm/upm-resources/package.json.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7a8d2fc07b337403ebbec98e23183b60
+guid: 856af27ca1ff04989a2404da89f2a7e0
 TextScriptImporter:
   externalObjects: {}
   userData: 


### PR DESCRIPTION
Some assets in the performance upm package had guid conflicts with the notifier package. 
These are fixed now.

Also added a link to the public documentation in the package readme.