### PR TITLE
Fix typo in example: scean -> scene

### DIFF
--- a/example/Assets/Scenes/Example.unity
+++ b/example/Assets/Scenes/Example.unity
@@ -1510,7 +1510,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Do Scean load
+  m_text: Do Scene load
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}


### PR DESCRIPTION
Fixes a typo in the example scene where a button was incorrectly named.