### PR TITLE
longer timeout to allow first request to process

### DIFF
--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Persistence/PValueRetry.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Persistence/PValueRetry.cs
@@ -1,14 +1,9 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using System.Threading;
-using BugsnagUnityPerformance;
-using UnityEngine;
-
+﻿
 public class PValueRetry : Scenario
 {
     public override void PrepareConfig(string apiKey, string host)
     {
         base.PrepareConfig(apiKey, host);
-        SetPValueCheckIntervalSeconds(1);
+        SetPValueCheckIntervalSeconds(3);
     }
 }


### PR DESCRIPTION
## Goal

Repeate rate for p value requests was set too low and the initial request did not have time to finish.

