### PR TITLE
add unity 2022 to CI

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -34,6 +34,7 @@ steps:
         upload:
           - maze_output/**/*
           - '*-mazerunner.log'
+          - 'clear_cache.log'
           - maze_output/metrics.csv
     commands:
       - features/scripts/run-macos-ci-tests.sh

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -38,6 +38,43 @@ steps:
           - maze_output/metrics.csv
     commands:
       - features/scripts/run-macos-ci-tests.sh
+  - label: ':macos: Build macos test fixture for Unity 2022'
+    timeout_in_minutes: 30
+    key: build-macos-fixture-2022
+    depends_on: build-artifacts
+    env:
+      UNITY_PERFORMANCE_VERSION: 2022.3.2f1
+    plugins:
+      'artifacts#v1.9.0':
+        download:
+          - upm-package.zip
+        upload:
+          - features/fixtures/mazerunner/mazerunner_2022.3.2f1.zip
+          - features/fixtures/build_macos.log
+    commands:
+      - 'rake test:macos:build'
+    retry:
+      automatic:
+        - exit_status: '*'
+          limit: 1
+  - label: Run MacOS e2e tests for Unity 2022
+    timeout_in_minutes: 60
+    depends_on: build-macos-fixture-2022
+    agents:
+      queue: macos-12-arm-unity
+    env:
+      UNITY_PERFORMANCE_VERSION: 2022.3.2f1
+    plugins:
+      'artifacts#v1.9.0':
+        download:
+          - features/fixtures/mazerunner/mazerunner_2022.3.2f1.zip
+        upload:
+          - maze_output/**/*
+          - '*-mazerunner.log'
+          - 'clear_cache.log'
+          - maze_output/metrics.csv
+    commands:
+      - features/scripts/run-macos-ci-tests.sh
   - label: ':android: Build Android test fixture for Unity 2020'
     timeout_in_minutes: 30
     key: build-android-fixture-2020
@@ -75,6 +112,50 @@ steps:
         service-ports: true
         command:
           - '--app=/app/features/fixtures/mazerunner/mazerunner_2020.3.48f1.apk'
+          - '--farm=bb'
+          - '--device=ANDROID_9|ANDROID_10|ANDROID_11|ANDROID_12|ANDROID_13'
+          - '--no-tunnel'
+          - '--aws-public-ip'
+    concurrency: 25
+    concurrency_group: bitbar-app
+    concurrency_method: eager
+  - label: ':android: Build Android test fixture for Unity 2022'
+    timeout_in_minutes: 30
+    key: build-android-fixture-2022
+    depends_on: build-artifacts
+    env:
+      UNITY_PERFORMANCE_VERSION: 2022.3.2f1
+    plugins:
+      'artifacts#v1.9.0':
+        download:
+          - upm-package.zip
+        upload:
+          - features/fixtures/mazerunner/mazerunner_2022.3.2f1.apk
+          - features/fixtures/import_package.log
+          - features/fixtures/build_android.log
+    commands:
+      - 'rake test:android:build'
+    retry:
+      automatic:
+        - exit_status: '*'
+          limit: 1
+  - label: ':bitbar: Run Android e2e tests for Unity 2022'
+    timeout_in_minutes: 60
+    depends_on: build-android-fixture-2022
+    agents:
+      queue: opensource
+    plugins:
+      'artifacts#v1.9.0':
+        download:
+          - features/fixtures/mazerunner/mazerunner_2022.3.2f1.apk
+        upload:
+          - maze_output/**/*
+      'docker-compose#v4.8.0':
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - '--app=/app/features/fixtures/mazerunner/mazerunner_2022.3.2f1.apk'
           - '--farm=bb'
           - '--device=ANDROID_9|ANDROID_10|ANDROID_11|ANDROID_12|ANDROID_13'
           - '--no-tunnel'
@@ -140,6 +221,71 @@ steps:
         service-ports: true
         command:
           - '--app=/app/features/fixtures/mazerunner/mazerunner_2020.3.48f1.ipa'
+          - '--farm=bb'
+          - '--device=IOS_15'
+          - '--no-tunnel'
+          - '--aws-public-ip'
+    concurrency: 25
+    concurrency_group: bitbar-app
+    concurrency_method: eager
+  - label: ':ios: Generate Xcode project - Unity 2022'
+    timeout_in_minutes: 30
+    key: generate-fixture-project-2022
+    depends_on: build-artifacts
+    env:
+      UNITY_PERFORMANCE_VERSION: 2022.3.2f1
+    plugins:
+      'artifacts#v1.9.0':
+        download:
+          - upm-package.zip
+        upload:
+          - features/fixtures/generateXcodeProject.log
+          - project_2022.tgz
+    commands:
+      - 'rake test:ios:generate_xcode'
+      - tar -zvcf project_2022.tgz features/fixtures/mazerunner/mazerunner_xcode
+    retry:
+      automatic:
+        - exit_status: '*'
+          limit: 1
+  - label: ':ios: Build iOS test fixture for Unity 2022'
+    timeout_in_minutes: 30
+    key: build-ios-fixture-2022
+    depends_on: generate-fixture-project-2022
+    env:
+      DEVELOPER_DIR: /Applications/Xcode14.0.app
+      UNITY_PERFORMANCE_VERSION: 2022.3.2f1
+    plugins:
+      'artifacts#v1.9.0':
+        download:
+          - project_2022.tgz
+        upload:
+          - features/fixtures/mazerunner/mazerunner_2022.3.2f1.ipa
+          - features/fixtures/unity.log
+    commands:
+      - tar -zxf project_2022.tgz features/fixtures/mazerunner
+      - 'rake test:ios:build_xcode'
+    retry:
+      automatic:
+        - exit_status: '*'
+          limit: 1
+  - label: ':bitbar: Run iOS e2e tests for Unity 2022'
+    timeout_in_minutes: 60
+    depends_on: build-ios-fixture-2022
+    agents:
+      queue: opensource
+    plugins:
+      'artifacts#v1.9.0':
+        download:
+          - features/fixtures/mazerunner/mazerunner_2022.3.2f1.ipa
+        upload:
+          - maze_output/**/*
+      'docker-compose#v4.8.0':
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - '--app=/app/features/fixtures/mazerunner/mazerunner_2022.3.2f1.ipa'
           - '--farm=bb'
           - '--device=IOS_15'
           - '--no-tunnel'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -48,6 +48,7 @@ steps:
         upload:
           - maze_output/**/*
           - '*-mazerunner.log'
+          - 'clear_cache.log'
           - maze_output/metrics.csv
     commands:
       - features/scripts/run-macos-ci-tests.sh

--- a/features/fixtures/mazerunner/Assets/Editor/Builder.cs
+++ b/features/fixtures/mazerunner/Assets/Editor/Builder.cs
@@ -41,7 +41,9 @@ public class Builder : MonoBehaviour
         PlayerSettings.SetApplicationIdentifier(BuildTargetGroup.Android, "com.bugsnag.fixtures.unity.performance.android");
         var opts = CommonOptions("mazerunner.apk");
         opts.target = BuildTarget.Android;
-
+#if UNITY_2022_1_OR_NEWER
+        PlayerSettings.insecureHttpOption = InsecureHttpOption.AlwaysAllowed;
+#endif
         var result = BuildPipeline.BuildPlayer(opts);
         Debug.Log("Result: " + result);
     }

--- a/features/fixtures/mazerunner/Assets/Editor/DisablingBitcodeiOS.cs
+++ b/features/fixtures/mazerunner/Assets/Editor/DisablingBitcodeiOS.cs
@@ -1,23 +1,21 @@
-#if UNITY_IOS
+
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using UnityEngine;
 using UnityEditor;
 using UnityEditor.Callbacks;
-using UnityEditor.iOS.Xcode;
 
 public class DisablingBitcodeiOS
 {
-
     [PostProcessBuild(1000)]
     public static void PostProcessBuildAttribute(BuildTarget target, string pathToBuildProject)
     {
         if (target == BuildTarget.iOS)
         {
-            string projectPath = PBXProject.GetPBXProjectPath(pathToBuildProject);
+            string projectPath = UnityEditor.iOS.Xcode.PBXProject.GetPBXProjectPath(pathToBuildProject);
 
-            PBXProject pbxProject = new PBXProject();
+            var pbxProject = new UnityEditor.iOS.Xcode.PBXProject();
             pbxProject.ReadFromFile(projectPath);
 #if UNITY_2019_3_OR_NEWER
                 var targetGuid = pbxProject.GetUnityMainTargetGuid();
@@ -35,7 +33,5 @@ public class DisablingBitcodeiOS
             File.WriteAllText(projectPath, projectInString);
         }
     }
-
 }
 
-#endif

--- a/features/fixtures/mazerunner/Assets/Editor/DisablingBitcodeiOS.cs
+++ b/features/fixtures/mazerunner/Assets/Editor/DisablingBitcodeiOS.cs
@@ -1,0 +1,41 @@
+#if UNITY_IOS
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+using UnityEditor;
+using UnityEditor.Callbacks;
+using UnityEditor.iOS.Xcode;
+
+public class DisablingBitcodeiOS
+{
+
+    [PostProcessBuild(1000)]
+    public static void PostProcessBuildAttribute(BuildTarget target, string pathToBuildProject)
+    {
+        if (target == BuildTarget.iOS)
+        {
+            string projectPath = PBXProject.GetPBXProjectPath(pathToBuildProject);
+
+            PBXProject pbxProject = new PBXProject();
+            pbxProject.ReadFromFile(projectPath);
+#if UNITY_2019_3_OR_NEWER
+                var targetGuid = pbxProject.GetUnityMainTargetGuid();
+#else
+            var targetName = PBXProject.GetUnityTargetName();
+            var targetGuid = pbxProject.TargetGuidByName(targetName);
+#endif
+            pbxProject.SetBuildProperty(targetGuid, "ENABLE_BITCODE", "NO");
+            pbxProject.WriteToFile(projectPath);
+
+            var projectInString = File.ReadAllText(projectPath);
+
+            projectInString = projectInString.Replace("ENABLE_BITCODE = YES;",
+                $"ENABLE_BITCODE = NO;");
+            File.WriteAllText(projectPath, projectInString);
+        }
+    }
+
+}
+
+#endif

--- a/features/fixtures/mazerunner/Assets/Editor/DisablingBitcodeiOS.cs.meta
+++ b/features/fixtures/mazerunner/Assets/Editor/DisablingBitcodeiOS.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7c2c2e2275f81452f85b06b3f114f684
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/mazerunner/Assets/Plugins/Android/AndroidManifest.xml
+++ b/features/fixtures/mazerunner/Assets/Plugins/Android/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.bugsnag.fixtures.unity.performance.android">
     <application android:usesCleartextTraffic="true" android:label="@string/app_name">
-        <activity android:name="com.unity3d.player.UnityPlayerActivity" android:label="@string/app_name">
+        <activity android:name="com.unity3d.player.UnityPlayerActivity" android:label="@string/app_name" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -17,7 +17,7 @@ When('I clear the Bugsnag cache') do
   case Maze::Helper.get_current_platform
   when 'macos', 'webgl'
     # Call executable directly rather than use open, which flakes on CI
-    log = File.join(Dir.pwd, 'mazerunner.log')
+    log = File.join(Dir.pwd, 'clear_cache.log')
     command = "#{Maze.config.app}/Contents/MacOS/Mazerunner --args -logfile #{log} > /dev/null"
     Maze::Runner.run_command(command, blocking: false)
     execute_command('clear_cache')


### PR DESCRIPTION
## Goal

Add unity 2022 builds to ci

## Changeset

- added required steps to pipeline
- updated fixtures to handle 2022 builds
- improved macos logging

## Testing

covered by existing scenarios