### PR TITLE
PLAT-10777 fix mobile device version keys

### DIFF
--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Models/ResourceModel.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Models/ResourceModel.cs
@@ -70,18 +70,18 @@ namespace BugsnagUnityPerformance
         {
             if (!string.IsNullOrEmpty(config.BundleVersion))
             {
-                return new AttributeModel("device.bundle_version",  config.BundleVersion);
+                return new AttributeModel("bugsnag.app.bundle_version",  config.BundleVersion);
             }
-            return new AttributeModel("device.bundle_version", iOSNative.GetBundleVersion());
+            return new AttributeModel("bugsnag.app.bundle_version", iOSNative.GetBundleVersion());
         }
 
         private AttributeModel GetAndroidVersionCode(PerformanceConfiguration config)
         {
             if (config.VersionCode > -1)
             {
-                return new AttributeModel("device.version_code", config.VersionCode.ToString());
+                return new AttributeModel("bugsnag.app.version_code", config.VersionCode.ToString());
             }
-            return new AttributeModel("device.version_code", AndroidNative.GetVersionCode());
+            return new AttributeModel("bugsnag.app.version_code", AndroidNative.GetVersionCode());
         }
 
         private AttributeModel GetArch()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## TBD ()
+
+### Additions
+
+
+
+### Bug Fixes
+
+- Fixed issue where the android version code and coca bundle version were incorrectly labled. [#76](https://github.com/bugsnag/bugsnag-unity-performance/pull/76)
+
+
 ## v1.2.0 (2023-08-18)
 
 ### Additions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fixes
 
-- Fixed issue where the android version code and coca bundle version were incorrectly labled. [#76](https://github.com/bugsnag/bugsnag-unity-performance/pull/76)
+- Fixed issue where the Android version code and iOS bundle version were incorrectly labelled [#76](https://github.com/bugsnag/bugsnag-unity-performance/pull/76)
 
 
 ## v1.2.0 (2023-08-18)

--- a/features/configuration.feature
+++ b/features/configuration.feature
@@ -48,7 +48,7 @@ Feature: Configuration tests
     And I wait for 1 span
     Then the trace Bugsnag-Integrity header is valid
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "BundleVersion"
-    * the trace payload field "resourceSpans.0.resource" string attribute "device.bundle_version" equals "1.2.3_BundleVersion"
+    * the trace payload field "resourceSpans.0.resource" string attribute "bugsnag.app.bundle_version" equals "1.2.3_BundleVersion"
 
   @android_only
   Scenario: Version Code
@@ -56,4 +56,4 @@ Feature: Configuration tests
     And I wait for 1 span
     Then the trace Bugsnag-Integrity header is valid
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "VersionCode"
-    * the trace payload field "resourceSpans.0.resource" string attribute "device.version_code" equals "123"
+    * the trace payload field "resourceSpans.0.resource" string attribute "bugsnag.app.version_code" equals "123"

--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -46,7 +46,7 @@ Feature: Manual creation of spans
     And the trace "Bugsnag-Api-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"  
 
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * the trace payload field "resourceSpans.0.resource" string attribute "device.version_code" exists
+    * the trace payload field "resourceSpans.0.resource" string attribute "bugsnag.app.version_code" exists
 
  @ios_only
   Scenario: iOS Specific Resource Attributes
@@ -56,4 +56,4 @@ Feature: Manual creation of spans
     And the trace "Bugsnag-Api-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"  
 
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * the trace payload field "resourceSpans.0.resource" string attribute "device.bundle_version" exists
+    * the trace payload field "resourceSpans.0.resource" string attribute "bugsnag.app.bundle_version" exists


### PR DESCRIPTION
## Goal

the android version code and cocoa bundle version attributes had the incorrect keys

## Testing

Updated tests to reflect the change