### PR TITLE
PLAT-10851 add macos plugin meta files

### DIFF
--- a/BugsnagPerformance/Assets/BugsnagPerformance/Plugins/MacOS/BugsnagUnityPerformanceMacOS.bundle.meta
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Plugins/MacOS/BugsnagUnityPerformanceMacOS.bundle.meta
@@ -49,13 +49,13 @@ PluginImporter:
     second:
       enabled: 0
       settings:
-        CPU: x86_64
+        CPU: AnyCPU
   - first:
       Standalone: OSXUniversal
     second:
       enabled: 1
       settings:
-        CPU: x86_64
+        CPU: AnyCPU
   - first:
       Standalone: Win
     second:

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Plugins/MacOS/BugsnagUnityPerformanceMacOS.bundle.meta
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Plugins/MacOS/BugsnagUnityPerformanceMacOS.bundle.meta
@@ -1,5 +1,6 @@
 fileFormatVersion: 2
-guid: 55c4177899d9340968f5127aba6350b7
+guid: 5297383e62dab4b2f83be1bc82f268cd
+folderAsset: yes
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2
@@ -48,13 +49,13 @@ PluginImporter:
     second:
       enabled: 0
       settings:
-        CPU: None
+        CPU: x86_64
   - first:
       Standalone: OSXUniversal
     second:
       enabled: 1
       settings:
-        CPU: AnyCPU
+        CPU: x86_64
   - first:
       Standalone: Win
     second:

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Plugins/MacOS/BugsnagUnityPerformanceMacOS.bundle/Contents.meta
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Plugins/MacOS/BugsnagUnityPerformanceMacOS.bundle/Contents.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d157d4724325d43bb8adca286c609bd6
+guid: f165850b898b4480eb4983e9d89a2bcd
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Plugins/MacOS/BugsnagUnityPerformanceMacOS.bundle/Contents/Info.plist.meta
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Plugins/MacOS/BugsnagUnityPerformanceMacOS.bundle/Contents/Info.plist.meta
@@ -1,6 +1,5 @@
 fileFormatVersion: 2
-guid: d157d4724325d43bb8adca286c609bd6
-folderAsset: yes
+guid: 0c7236e083f834ea9a81b37849b5bd71
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Plugins/MacOS/BugsnagUnityPerformanceMacOS.bundle/Contents/MacOS.meta
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Plugins/MacOS/BugsnagUnityPerformanceMacOS.bundle/Contents/MacOS.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d157d4724325d43bb8adca286c609bd6
+guid: 00914ab8ecc454c14abbb11c47bc4013
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Plugins/MacOS/BugsnagUnityPerformanceMacOS.bundle/Contents/MacOS/BugsnagUnityPerformanceMacOS.meta
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Plugins/MacOS/BugsnagUnityPerformanceMacOS.bundle/Contents/MacOS/BugsnagUnityPerformanceMacOS.meta
@@ -1,6 +1,5 @@
 fileFormatVersion: 2
-guid: d157d4724325d43bb8adca286c609bd6
-folderAsset: yes
+guid: 197b48b91131845e0a245599f0316a17
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Plugins/MacOS/BugsnagUnityPerformanceMacOS.bundle/Contents/_CodeSignature.meta
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Plugins/MacOS/BugsnagUnityPerformanceMacOS.bundle/Contents/_CodeSignature.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d157d4724325d43bb8adca286c609bd6
+guid: c5502ade6eb3545e9beefd3dfcfa0b2b
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Plugins/MacOS/BugsnagUnityPerformanceMacOS.bundle/Contents/_CodeSignature/CodeResources.meta
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Plugins/MacOS/BugsnagUnityPerformanceMacOS.bundle/Contents/_CodeSignature/CodeResources.meta
@@ -1,6 +1,5 @@
 fileFormatVersion: 2
-guid: d157d4724325d43bb8adca286c609bd6
-folderAsset: yes
+guid: 59e565741ae2641f290e1ddf47aa8841
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 - Fixed issue where the Android version code and iOS bundle version were incorrectly labelled [#76](https://github.com/bugsnag/bugsnag-unity-performance/pull/76)
 
+- Fixed issue where some unity version required meta files within the macos bundle [#80](https://github.com/bugsnag/bugsnag-unity-performance/pull/80)
+
 
 ## v1.2.0 (2023-08-18)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,4 +49,24 @@ Once the github release is confirmed a UPM release should be deployed
    git push origin v1.x.x
    ```
 
+## Known Issues
+
+### MacOS Native Bundle Meta Files
+
+This SDK contains a MacOS bundle as a native plugin. Some versions of Unity (There seems to be no pattern, we have seen different behaviour in different patch versions of 2019 2020 & 2021) import that bundle as a single file, others import it as a folder. 
+
+When importing as a single file it creates only 1 meta file, but when importing as a folder, it creates meta files for every file and folder within.
+
+This causes a problem because we distribute the SDK as a UPM package. When importing a UPM package, Unity cannot create meta files on the fly, so if we only distribute 1 meta file for the root of the bundle, assuming that it will be imported as a single file, and then Unity imports it as a folder, it will throw errors stating that it can’t find meta files for the contents of the directory and will not import the plugin.
+
+To solve this, whenever the native code for MacOS is rebuilt (currently only when changes have been made) then the resulting bundle should be manually imported into unity 2019 and then copied over to the plugins folder of the dev project along with all relevant meta files.
+
+
+
+
+
+
+
+
+
 


### PR DESCRIPTION
## Goal

Some versions of Unity see a macos bundle as a single file, but some see it as a directory and therefore require meta files for all files within the bundle in order to build correctly.

## Changeset

- added required meta files

## Testing

Covered by existing tests

## Full details of the issue:

This SDK contains a MacOS bundle as a native plugin. Some versions of Unity (There seems to be no pattern, we have seen different behaviour in different patch versions of 2019 2020 & 2021) import that bundle as a single file, others import it as a folder. 

When importing as a single file it creates only 1 meta file, but when importing as a folder, it creates meta files for every file and folder within.

This causes a problem because we distribute the SDK as a UPM package. When importing a UPM package, Unity cannot create meta files on the fly, so if we only distribute 1 meta file for the root of the bundle, assuming that it will be imported as a single file, and then Unity imports it as a folder, it will throw errors stating that it can’t find meta files for the contents of the directory and will not import the plugin.

To solve this, whenever the native code for MacOS is rebuilt (currently only when changes have been made) then the resulting bundle should be manually imported into unity 2019 and then copied over to the plugins folder of the dev project along with all relevant meta files.