### PR TITLE
Rationalise BitBar CI concurrency group

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -117,7 +117,7 @@ steps:
           - '--no-tunnel'
           - '--aws-public-ip'
     concurrency: 25
-    concurrency_group: bitbar-app
+    concurrency_group: bitbar
     concurrency_method: eager
   - label: ':android: Build Android test fixture for Unity 2022'
     timeout_in_minutes: 30
@@ -161,7 +161,7 @@ steps:
           - '--no-tunnel'
           - '--aws-public-ip'
     concurrency: 25
-    concurrency_group: bitbar-app
+    concurrency_group: bitbar
     concurrency_method: eager
   - label: ':ios: Generate Xcode project - Unity 2020'
     timeout_in_minutes: 30
@@ -226,7 +226,7 @@ steps:
           - '--no-tunnel'
           - '--aws-public-ip'
     concurrency: 25
-    concurrency_group: bitbar-app
+    concurrency_group: bitbar
     concurrency_method: eager
   - label: ':ios: Generate Xcode project - Unity 2022'
     timeout_in_minutes: 30
@@ -291,5 +291,5 @@ steps:
           - '--no-tunnel'
           - '--aws-public-ip'
     concurrency: 25
-    concurrency_group: bitbar-app
+    concurrency_group: bitbar
     concurrency_method: eager

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -149,7 +149,7 @@ steps:
           - '--no-tunnel'
           - '--aws-public-ip'
     concurrency: 25
-    concurrency_group: bitbar-app
+    concurrency_group: bitbar
     concurrency_method: eager
   - label: ':ios: Generate Xcode project - Unity 2021'
     timeout_in_minutes: 30
@@ -214,7 +214,7 @@ steps:
           - '--no-tunnel'
           - '--aws-public-ip'
     concurrency: 25
-    concurrency_group: bitbar-app
+    concurrency_group: bitbar
     concurrency_method: eager
   - label: Conditionally trigger full set of tests
     timeout_in_minutes: 30


### PR DESCRIPTION
## Goal

NOTE: Please let me merge this PR myself, it needs to be merged as the same time as several others to avoid unnecessary failures on CI.

Rationalise the Buildkite concurrency group used to control access to BitBar across all of our repos.

## Design

We were using separate groups fro web and device usage, when in fact they are counted towards the same usage limit.  All groups are now being renamed to simply 'bitbar' with a limit of 25.

The main mistake that I could make here is missing an instance of the old groups (`bitbar-app` and `bitbar-web`, so I am using the global find and replace function of my IDE.

## Changeset

Buildkite concurrency group changes only.

## Testing

Verified by peer review.  
