### PR TITLE
Use the latest version of Maze Runner for macOS tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'rake'
 
 unless Gem.win_platform?
   # Use official Maze Runner release
-  gem 'bugsnag-maze-runner', '~> 8.4.1'
+  gem 'bugsnag-maze-runner', '~> 8.0'
 
   # Use a specific Maze Runner branch
   #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'master'

--- a/features/scripts/run-macos-ci-tests.sh
+++ b/features/scripts/run-macos-ci-tests.sh
@@ -3,5 +3,6 @@ pushd features/fixtures/mazerunner/
   unzip mazerunner_macos_${UNITY_PERFORMANCE_VERSION:0:4}.zip
 popd
 
+rm -rf Gemfile.lock
 bundle install
 bundle exec maze-runner --app=features/fixtures/mazerunner/mazerunner_macos_${UNITY_PERFORMANCE_VERSION:0:4}.app --os=macos features 


### PR DESCRIPTION
## Goal

Use the latest version of Maze Runner for macOS tests.

## Testing

Covered by a basic CI run.