### PR TITLE
E2e tests - fail fast

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -5,6 +5,7 @@ aliases:
 
 agents:
   queue: macos-12-arm-unity
+
 steps:
   - label: ':macos: Build macos test fixture for Unity 2020'
     timeout_in_minutes: 30
@@ -25,6 +26,7 @@ steps:
       automatic:
         - exit_status: '*'
           limit: 1
+
   - label: Run MacOS e2e tests for Unity 2020
     timeout_in_minutes: 60
     depends_on: build-macos-fixture-2020
@@ -43,6 +45,7 @@ steps:
           - maze_output/metrics.csv
     commands:
       - features/scripts/run-macos-ci-tests.sh
+
   - label: ':macos: Build macos test fixture for Unity 2022'
     timeout_in_minutes: 30
     key: build-macos-fixture-2022
@@ -62,6 +65,7 @@ steps:
       automatic:
         - exit_status: '*'
           limit: 1
+
   - label: Run MacOS e2e tests for Unity 2022
     timeout_in_minutes: 60
     depends_on: build-macos-fixture-2022
@@ -185,6 +189,7 @@ steps:
       automatic:
         - exit_status: '*'
           limit: 1
+
   - label: ':bitbar: Run Android e2e tests for Unity 2020'
     timeout_in_minutes: 60
     depends_on: build-android-fixture-2020
@@ -206,9 +211,11 @@ steps:
           - '--device=ANDROID_9|ANDROID_10|ANDROID_11|ANDROID_12|ANDROID_13'
           - '--no-tunnel'
           - '--aws-public-ip'
+          - '--fail-fast'
     concurrency: 25
     concurrency_group: bitbar
     concurrency_method: eager
+
   - label: ':android: Build Android test fixture for Unity 2022'
     timeout_in_minutes: 30
     key: build-android-fixture-2022
@@ -229,6 +236,7 @@ steps:
       automatic:
         - exit_status: '*'
           limit: 1
+
   - label: ':bitbar: Run Android e2e tests for Unity 2022'
     timeout_in_minutes: 60
     depends_on: build-android-fixture-2022
@@ -250,9 +258,11 @@ steps:
           - '--device=ANDROID_9|ANDROID_10|ANDROID_11|ANDROID_12|ANDROID_13'
           - '--no-tunnel'
           - '--aws-public-ip'
+          - '--fail-fast'
     concurrency: 25
     concurrency_group: bitbar
     concurrency_method: eager
+
   - label: ':ios: Generate Xcode project - Unity 2020'
     timeout_in_minutes: 30
     key: generate-fixture-project-2020
@@ -273,6 +283,7 @@ steps:
       automatic:
         - exit_status: '*'
           limit: 1
+
   - label: ':ios: Build iOS test fixture for Unity 2020'
     timeout_in_minutes: 30
     key: build-ios-fixture-2020
@@ -294,6 +305,7 @@ steps:
       automatic:
         - exit_status: '*'
           limit: 1
+
   - label: ':bitbar: Run iOS e2e tests for Unity 2020'
     timeout_in_minutes: 60
     depends_on: build-ios-fixture-2020
@@ -315,9 +327,11 @@ steps:
           - '--device=IOS_15'
           - '--no-tunnel'
           - '--aws-public-ip'
+          - '--fail-fast'
     concurrency: 25
     concurrency_group: bitbar
     concurrency_method: eager
+
   - label: ':ios: Generate Xcode project - Unity 2022'
     timeout_in_minutes: 30
     key: generate-fixture-project-2022
@@ -338,6 +352,7 @@ steps:
       automatic:
         - exit_status: '*'
           limit: 1
+
   - label: ':ios: Build iOS test fixture for Unity 2022'
     timeout_in_minutes: 30
     key: build-ios-fixture-2022
@@ -359,6 +374,7 @@ steps:
       automatic:
         - exit_status: '*'
           limit: 1
+
   - label: ':bitbar: Run iOS e2e tests for Unity 2022'
     timeout_in_minutes: 60
     depends_on: build-ios-fixture-2022
@@ -380,6 +396,7 @@ steps:
           - '--device=IOS_15'
           - '--no-tunnel'
           - '--aws-public-ip'
+          - '--fail-fast'
     concurrency: 25
     concurrency_group: bitbar
     concurrency_method: eager

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -137,6 +137,7 @@ steps:
       automatic:
         - exit_status: '*'
           limit: 1
+
   - label: Run MacOS e2e tests for Unity 2021
     timeout_in_minutes: 60
     depends_on: build-macos-fixture-2021
@@ -155,6 +156,7 @@ steps:
           - maze_output/metrics.csv
     commands:
       - features/scripts/run-macos-ci-tests.sh
+
   - label: ':android: Build Android test fixture for Unity 2021'
     timeout_in_minutes: 30
     key: build-android-fixture-2021
@@ -175,6 +177,7 @@ steps:
       automatic:
         - exit_status: '*'
           limit: 1
+
   - label: ':bitbar: Run Android e2e tests for Unity 2021'
     timeout_in_minutes: 60
     depends_on: build-android-fixture-2021
@@ -196,9 +199,11 @@ steps:
           - '--device=ANDROID_9|ANDROID_10|ANDROID_11|ANDROID_12|ANDROID_13'
           - '--no-tunnel'
           - '--aws-public-ip'
+          - '--fail-fast'
     concurrency: 25
     concurrency_group: bitbar
     concurrency_method: eager
+
   - label: ':ios: Generate Xcode project - Unity 2021'
     timeout_in_minutes: 30
     key: generate-fixture-project-2021
@@ -219,6 +224,7 @@ steps:
       automatic:
         - exit_status: '*'
           limit: 1
+
   - label: ':ios: Build iOS test fixture for Unity 2021'
     timeout_in_minutes: 30
     key: build-ios-fixture-2021
@@ -240,6 +246,7 @@ steps:
       automatic:
         - exit_status: '*'
           limit: 1
+
   - label: ':bitbar: Run iOS e2e tests for Unity 2021'
     timeout_in_minutes: 60
     depends_on: build-ios-fixture-2021
@@ -261,6 +268,7 @@ steps:
           - '--device=IOS_15'
           - '--no-tunnel'
           - '--aws-public-ip'
+          - '--fail-fast'
     concurrency: 25
     concurrency_group: bitbar
     concurrency_method: eager

--- a/features/scripts/run-macos-ci-tests.sh
+++ b/features/scripts/run-macos-ci-tests.sh
@@ -5,4 +5,4 @@ popd
 
 rm -rf Gemfile.lock
 bundle install
-bundle exec maze-runner --app=features/fixtures/mazerunner/mazerunner_macos_${UNITY_PERFORMANCE_VERSION:0:4}.app --os=macos features 
+bundle exec maze-runner --app=features/fixtures/mazerunner/mazerunner_macos_${UNITY_PERFORMANCE_VERSION:0:4}.app --os=macos --fail-fast features

--- a/features/scripts/run-webgl-ci-tests.sh
+++ b/features/scripts/run-webgl-ci-tests.sh
@@ -6,4 +6,4 @@ popd
 
 bundle install
 
-bundle exec maze-runner --farm=local --browser=firefox features
+bundle exec maze-runner --farm=local --browser=firefox --fail-fast features

--- a/features/scripts/run-windows-ci-tests.sh
+++ b/features/scripts/run-windows-ci-tests.sh
@@ -4,4 +4,4 @@ pushd features/fixtures/mazerunner/build
 popd
 
 bundle install
-bundle exec maze-runner --app=features/fixtures/mazerunner/build/Windows/mazerunner_windows.exe --os=windows features
+bundle exec maze-runner --app=features/fixtures/mazerunner/build/Windows/mazerunner_windows.exe --os=windows --fail-fast features


### PR DESCRIPTION
## Goal

Save CI resources by failing a test run as soon as a 

## Testing

Covered by a full CI run.