### PR TITLE
Plat 10311 add generate anonymous id value

### DIFF
--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/CacheManager.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/CacheManager.cs
@@ -8,6 +8,7 @@ namespace BugsnagUnityPerformance
     public class CacheManager : IPhasedStartup
     {
         private int _maxPersistedBatchAgeSeconds;
+        private bool _deviceAutoGenerateId;
         private string _cacheDirectory;
         private string _deviceidFilePath;
         private string _persistentStateFilePath;
@@ -32,6 +33,8 @@ namespace BugsnagUnityPerformance
         public void Configure(PerformanceConfiguration config)
         {
             _maxPersistedBatchAgeSeconds = config.MaxPersistedBatchAgeSeconds;
+            _deviceAutoGenerateId = config.GenerateAnonymousId;
+
         }
 
         public void Start()
@@ -46,16 +49,24 @@ namespace BugsnagUnityPerformance
         {
             try
             {
-                if (File.Exists(_deviceidFilePath))
+                //if generateAnonymousId is true then store/report/generate else don't 
+                if (_deviceAutoGenerateId)
                 {
-                    // return existing cached device id
-                    return File.ReadAllText(_deviceidFilePath);
-                }
+                    if (File.Exists(_deviceidFilePath))
+                    {
+                        // return existing cached device id
+                        return File.ReadAllText(_deviceidFilePath);
+                    }
 
-                // create and cache new random device id
-                var newDeviceId = Guid.NewGuid().ToString();
-                WriteFile(_deviceidFilePath, _deviceidFilePath);
-                return newDeviceId;
+                    // create and cache new random device id
+                    var newDeviceId = Guid.NewGuid().ToString();
+                    WriteFile(_deviceidFilePath, _deviceidFilePath);
+                    return newDeviceId;
+                }
+                else
+                {
+                    return string.Empty;
+                }
             }
             catch
             {

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformanceSettingsObject.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformanceSettingsObject.cs
@@ -26,6 +26,8 @@ namespace BugsnagUnityPerformance
         public int VersionCode = -1;
         public string BundleVersion;
 
+        public bool GenerateAnonymousId = true;
+
         public static PerformanceConfiguration LoadConfiguration()
         {
             var settings = Resources.Load<BugsnagPerformanceSettingsObject>("Bugsnag/BugsnagPerformanceSettingsObject");
@@ -56,6 +58,8 @@ namespace BugsnagUnityPerformance
             config.AutoInstrumentAppStart = AutoInstrumentAppStart;
 
             config.Endpoint = Endpoint;
+
+            config.GenerateAnonymousId = GenerateAnonymousId;
             
             return config;
         }
@@ -78,6 +82,7 @@ namespace BugsnagUnityPerformance
             config.AppVersion = AppVersion;
             config.BundleVersion = BundleVersion;
             config.VersionCode = VersionCode;
+            config.GenerateAnonymousId = GenerateAnonymousId;
 
             return config;
         }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformanceSettingsObject.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformanceSettingsObject.cs
@@ -112,6 +112,8 @@ namespace BugsnagUnityPerformance
             config.AppVersion = (string)GetValueFromNotifer(notifierSettings, "AppVersion");
             config.BundleVersion = (string)GetValueFromNotifer(notifierSettings, "BundleVersion");
             config.VersionCode = (int)GetValueFromNotifer(notifierSettings, "VersionCode");
+            config.GenerateAnonymousId = (bool)GetValueFromNotifer(notifierSettings, "GenerateAnonymousId");
+
 
             autoStart = (bool)GetValueFromNotifer(notifierSettings, "StartAutomaticallyAtLaunch");
 

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
@@ -24,6 +24,7 @@ namespace BugsnagUnityPerformance
         public string AppVersion = Application.version;
         public int VersionCode = -1;
         public string BundleVersion;
+        public bool GenerateAnonymousId = true;
 
         public string[] EnabledReleaseStages;
 
@@ -37,8 +38,6 @@ namespace BugsnagUnityPerformance
         {
             ApiKey = apiKey;
         }
-
-        public bool GenerateAnonymousId = true;
       
     }
 }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
@@ -38,6 +38,7 @@ namespace BugsnagUnityPerformance
             ApiKey = apiKey;
         }
 
+        public bool GenerateAnonymousId = true;
       
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### TBD
+
+- Added methods to generate anonymous id value [#92](https://github.com/bugsnag/bugsnag-unity-performance/pull/92)
+
 ## v1.3.3 (2024-03-07)
 
 ### Bug Fixes


### PR DESCRIPTION
## Goal

<!-- Why is this change necessary? -->
Keep notifier in line with notifier spec

## Design

<!-- Why was this approach used? -->
boolean value in the configuration options which when set to false does not write, report or generate deviceId or persist to cache

## Changeset

<!-- What changed? -->
- Added GenerateAnonymousId boolean option to config
- Edited the CacheManager.cs GetDeviceId to check the value of config GenerateAnonymousId value

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->
Tested manually by setting to true and sending spans - which reported spans with device ID.
Then set to false and sent spans - which reported spans with no device ID