### PR TITLE
PLAT-11511 add apple privacy manifest

### DIFF
--- a/BugsnagPerformance/Assets/BugsnagPerformance/Plugins/iOS/PrivacyInfo.xcprivacy
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Plugins/iOS/PrivacyInfo.xcprivacy
@@ -2,6 +2,57 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeDeviceID</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeProductInteraction</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypePerformanceData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDiagnosticData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+	</array>
     <key>NSPrivacyAccessedAPITypes</key>
     <array>
         <dict>

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Plugins/iOS/PrivacyInfo.xcprivacy
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Plugins/iOS/PrivacyInfo.xcprivacy
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>C617.1</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Plugins/iOS/PrivacyInfo.xcprivacy.meta
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Plugins/iOS/PrivacyInfo.xcprivacy.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4e04710ee6dcb494e84dc04b4a1c05eb
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Additions
+
+- Added Apple privacy manifest due to IO api usage. Please see the [Unity documentation](https://docs.unity3d.com/2023.3/Documentation/Manual/apple-privacy-manifest-policy.html#CSharpDotNetAPIs) for more information. [#94](https://github.com/bugsnag/bugsnag-unity-performance/pull/94)
+
 ## v1.3.1 (2024-08-01)
 
 ### Bug Fixes


### PR DESCRIPTION
## Goal

Add a privacy manifest to Plugins>iOS because we use the file creation timestamp as detailed here: https://docs.unity3d.com/2023.3/Documentation/Manual/apple-privacy-manifest-policy.html#CSharpDotNetAPIs

## Testing

Manually tested that the file is present in a dry run release