### PR TITLE
fix `bugsnag.device.android_api_version` attribute type int to string

### DIFF
--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Models/ResourceModel.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Models/ResourceModel.cs
@@ -32,7 +32,7 @@ namespace BugsnagUnityPerformance
             AddNonNullAttribute(GetManufacturer());
             AddNonNullAttribute(GetArch());
             AddNonNullAttribute(GetNativeOsVersion());
-            AddNonNullAttribute(GetAndroidSdkInt());
+            AddNonNullAttribute(GetAndroidSdk());
         }
 
         private void AddNonNullAttribute(AttributeModel attributeModel)
@@ -155,11 +155,11 @@ namespace BugsnagUnityPerformance
             return new AttributeModel("os.version", osVersion);
         }
 
-        private AttributeModel GetAndroidSdkInt()
+        private AttributeModel GetAndroidSdk()
         {
             if (Application.platform == RuntimePlatform.Android)
             {
-                return new AttributeModel("bugsnag.device.android_api_version", AndroidNative.GetAndroidSDKInt());
+                return new AttributeModel("bugsnag.device.android_api_version", AndroidNative.GetAndroidSDKInt().ToString());
             }
             return null;
         }

--- a/features/configuration.feature
+++ b/features/configuration.feature
@@ -57,4 +57,4 @@ Feature: Configuration tests
     Then the trace Bugsnag-Integrity header is valid
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "VersionCode"
     * the trace payload field "resourceSpans.0.resource" string attribute "bugsnag.app.version_code" equals "123"
-    * the trace payload field "resourceSpans.0.resource" integer attribute "bugsnag.device.android_api_version" is greater than 0
+    * the trace payload field "resourceSpans.0.resource" string attribute "bugsnag.device.android_api_version" exists


### PR DESCRIPTION
## Goal

I would like to fix a bug on Android that spans sent to the OLTP server are not registered.

## Design

Looking at [the SDK implementation for Android](https://github.com/bugsnag/bugsnag-android-performance/blob/b8e9e0ace2da570fb1ebeb6da0db254d0b3da7c3/bugsnag-android-performance/src/main/kotlin/com/bugsnag/android/performance/internal/ResourceAttributes.kt#L20), it looks like using string type for `bugsnag.device.android_api_version` is the correct.

## Changeset

- Fix `bugsnag.device.android_api_version` attribute type int to string
- Fix a feature

## Testing

I confirmed on [my forked repository](https://github.com/pobo380/bugsnag-unity-performance-upm/tree/fix-bugsnag-device-android-api) that this fix worked out and spans are registered correctly.