### PR TITLE
Release v1.3.2

### DIFF
--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Version.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Version.cs
@@ -3,6 +3,6 @@
     internal static class Version
     {
         //TODO set this using sed or something in the release automation task
-        public const string VersionString = "1.3.0";
+        public const string VersionString = "1.3.1";
     }
 }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Version.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Version.cs
@@ -3,6 +3,6 @@
     internal static class Version
     {
         //TODO set this using sed or something in the release automation task
-        public const string VersionString = "1.3.1";
+        public const string VersionString = "1.3.2";
     }
 }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Models/ResourceModel.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Models/ResourceModel.cs
@@ -32,7 +32,7 @@ namespace BugsnagUnityPerformance
             AddNonNullAttribute(GetManufacturer());
             AddNonNullAttribute(GetArch());
             AddNonNullAttribute(GetNativeOsVersion());
-            AddNonNullAttribute(GetAndroidSdkInt());
+            AddNonNullAttribute(GetAndroidSdk());
         }
 
         private void AddNonNullAttribute(AttributeModel attributeModel)
@@ -155,11 +155,11 @@ namespace BugsnagUnityPerformance
             return new AttributeModel("os.version", osVersion);
         }
 
-        private AttributeModel GetAndroidSdkInt()
+        private AttributeModel GetAndroidSdk()
         {
             if (Application.platform == RuntimePlatform.Android)
             {
-                return new AttributeModel("bugsnag.device.android_api_version", AndroidNative.GetAndroidSDKInt());
+                return new AttributeModel("bugsnag.device.android_api_version", AndroidNative.GetAndroidSDKInt().ToString());
             }
             return null;
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,10 @@
 # Changelog
 
-## TBD
+## v1.3.1 (2024-31-01)
 
 ### Additions
 
 - Added Apple privacy manifest due to IO api usage. Please see the [Unity documentation](https://docs.unity3d.com/2023.3/Documentation/Manual/apple-privacy-manifest-policy.html#CSharpDotNetAPIs) for more information. [#94](https://github.com/bugsnag/bugsnag-unity-performance/pull/94)
-
-## v1.3.1 (2024-08-01)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## TBD ()
+## v1.3.2 (2024-14-02)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD ()
+
+### Bug Fixes
+
+- Fixed issue where the span attribute android_api_version was sent as a int attribute instead of a string [#99](https://github.com/bugsnag/bugsnag-unity-performance/pull/99)
+
 ## v1.3.1 (2024-31-01)
 
 ### Additions

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rake'
+gem 'cocoapods'
 
 unless Gem.win_platform?
   # Use official Maze Runner release

--- a/features/configuration.feature
+++ b/features/configuration.feature
@@ -57,4 +57,4 @@ Feature: Configuration tests
     Then the trace Bugsnag-Integrity header is valid
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "VersionCode"
     * the trace payload field "resourceSpans.0.resource" string attribute "bugsnag.app.version_code" equals "123"
-    * the trace payload field "resourceSpans.0.resource" integer attribute "bugsnag.device.android_api_version" is greater than 0
+    * the trace payload field "resourceSpans.0.resource" string attribute "bugsnag.device.android_api_version" exists


### PR DESCRIPTION
## v1.3.2 (2024-14-02)

### Bug Fixes

- Fixed issue where the span attribute android_api_version was sent as a int attribute instead of a string [#99](https://github.com/bugsnag/bugsnag-unity-performance/pull/99)