### PR TITLE
PLAT-11648 fix for some cultures causing incorrect parsing of the sampling header

### DIFF
--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Delivery.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Delivery.cs
@@ -173,7 +173,7 @@ namespace BugsnagUnityPerformance
                 var probabilityStr = req.GetResponseHeader("Bugsnag-Sampling-Probability");
                 if (probabilityStr != null)
                 {
-                    return Convert.ToDouble(probabilityStr);
+                    return double.Parse(probabilityStr, CultureInfo.InvariantCulture);
                 }
             }
             catch

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/TracePayload.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/TracePayload.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text;
 using Newtonsoft.Json;
 using System.Linq;
+using System.Globalization;
 
 namespace BugsnagUnityPerformance
 {
@@ -136,9 +137,9 @@ namespace BugsnagUnityPerformance
 
             foreach (KeyValuePair<double, int> pair in payload.SamplingHistogram)
             {
-                builder.Append(pair.Key);
+                builder.Append(pair.Key.ToString(CultureInfo.InvariantCulture));
                 builder.Append(':');
-                builder.Append(pair.Value);
+                builder.Append(pair.Value.ToString(CultureInfo.InvariantCulture));
                 builder.Append(';');
             }
             builder.Remove(builder.Length - 1, 1);


### PR DESCRIPTION
## Goal

The p value header was being parsed without specific formatting instructions, meaning that when running in different locals, it could be parsed incorrectly.

## Changeset

- Added specific culture instructions when parsing p values.

## Testing

E2E test added