### PR TITLE
PLAT-11880 discard open spans when app is backgrounded

### DIFF
--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/BugsnagPerformanceAppLifecycleListener.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/BugsnagPerformanceAppLifecycleListener.cs
@@ -1,0 +1,28 @@
+using UnityEngine;
+namespace BugsnagUnityPerformance
+{
+    public class BugsnagPerformanceAppLifecycleListener : MonoBehaviour
+    {
+        void Awake()
+        {
+            DontDestroyOnLoad(gameObject);
+        }
+
+        void OnApplicationFocus(bool hasFocus)
+        {
+            if (!hasFocus)
+            {
+                BugsnagPerformance.AppBackgrounded();
+            }
+        }
+
+        void OnApplicationPause(bool paused)
+        {
+            if (paused)
+            {
+                BugsnagPerformance.AppBackgrounded();
+            }
+        }
+
+    }
+}

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/BugsnagPerformanceAppLifecycleListener.cs.meta
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/BugsnagPerformanceAppLifecycleListener.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 41600a3af047a45258f0b7ee33a35ae6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Tracer.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Tracer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using UnityEngine;
 
@@ -135,7 +136,7 @@ namespace BugsnagUnityPerformance
                 {
                     return;
                 }
-                batch = _spanQueue;
+                batch = _spanQueue.Where(span => !span.WasAborted).ToList();
                 _spanQueue = new List<Span>();
                 _lastBatchSendTime = DateTimeOffset.UtcNow;
                 _delivery.Deliver(batch);

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/Span.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/Span.cs
@@ -22,6 +22,7 @@ namespace BugsnagUnityPerformance
         private object _endLock = new object();
         private OnSpanEnd _onSpanEnd;
         internal bool IsAppStartSpan;
+        internal bool WasAborted;
 
         public Span(string name, SpanKind kind, string id, string traceId, string parentSpanId, DateTimeOffset startTime, bool? isFirstClass, OnSpanEnd onSpanEnd)
         {
@@ -75,7 +76,9 @@ namespace BugsnagUnityPerformance
                 {
                     return;
                 }
+                WasAborted = true;
                 Ended = true;
+                _onSpanEnd(this);
             }
         }
 

--- a/features/persistence.feature
+++ b/features/persistence.feature
@@ -47,7 +47,8 @@ Feature: Trace and state persistence
     And I run the game in the "PValueUpdate" state
     Then I should receive no traces
 
-  @skip_webgl #Pending PLAT-8151
+  @skip_webgl #Pending PLAT-8151 
+  @skip_macos #Pending PLAT-12011
   Scenario: P value response 0.0 then 1.0
     Given I set the sampling probability for the next traces to "0"
     And I run the game in the "PValueUpdate" state


### PR DESCRIPTION
## Goal

discard open spans when app is backgrounded

## Testing

Manually tested as there is no way to reliably backgroudn and then foreground a unity app