### PR TITLE
allow custom span end time

### DIFF
--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/Span.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/Span.cs
@@ -40,21 +40,7 @@ namespace BugsnagUnityPerformance
             _onSpanEnd = onSpanEnd;
         }
 
-        public void End()
-        {
-            lock (_endLock)
-            {
-                if (Ended)
-                {
-                    return;
-                }
-                Ended = true;
-            }
-            EndTime = DateTimeOffset.UtcNow;
-            _onSpanEnd(this);
-        }
-
-        public void End(DateTimeOffset? endTime)
+        public void End(DateTimeOffset? endTime = null)
         {
             lock (_endLock)
             {
@@ -110,7 +96,7 @@ namespace BugsnagUnityPerformance
             _onSpanEnd(this);
         }
 
-        public void EndNetworkSpan(int statusCode = -1, int requestContentLength = -1, int responseContentLength = -1)
+        public void EndNetworkSpan(int statusCode = -1, int requestContentLength = -1, int responseContentLength = -1, DateTimeOffset? endTime = null)
         {
             lock (_endLock)
             {
@@ -121,7 +107,7 @@ namespace BugsnagUnityPerformance
                 Ended = true;
             }
 
-            EndTime = DateTimeOffset.UtcNow;
+            EndTime = endTime == null ? DateTimeOffset.UtcNow : endTime.Value;
 
             if (statusCode > -1)
             {

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/Span.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/Span.cs
@@ -54,7 +54,7 @@ namespace BugsnagUnityPerformance
             _onSpanEnd(this);
         }
 
-        internal void End(DateTimeOffset? endTime)
+        public void End(DateTimeOffset? endTime)
         {
             lock (_endLock)
             {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug Fixes
+
+- Fixed issue where spans could not be ended with a custom end time. [#106](https://github.com/bugsnag/bugsnag-unity-performance/pull/106)
+
+
 ## v1.3.3 (2024-03-07)
 
 ### Bug Fixes

--- a/features/fixtures/mazerunner/Assets/Scenes/MainScene.unity
+++ b/features/fixtures/mazerunner/Assets/Scenes/MainScene.unity
@@ -151,6 +151,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1513513353}
   m_RootOrder: 0
@@ -267,6 +268,7 @@ GameObject:
   m_Component:
   - component: {fileID: 259057445}
   - component: {fileID: 259057446}
+  - component: {fileID: 259057447}
   m_Layer: 0
   m_Name: ManualSpans
   m_TagString: Untagged
@@ -284,6 +286,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1294582014}
   m_RootOrder: 0
@@ -298,6 +301,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: cb0c44dcd373341599ace342676625b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &259057447
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 259057444}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1acdfac80082464180a997600222189, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &320782971
@@ -331,6 +346,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1294582014}
   m_RootOrder: 2
@@ -425,6 +441,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
   m_HorizontalAxis: Horizontal
   m_VerticalAxis: Vertical
   m_SubmitButton: Submit
@@ -457,6 +474,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 3
@@ -540,6 +558,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -574,6 +593,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1294582014}
   m_RootOrder: 5
@@ -654,6 +674,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1294582014}
   m_RootOrder: 7
@@ -709,6 +730,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1294582014}
   m_RootOrder: 3
@@ -751,6 +773,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 259057445}
   - {fileID: 1452957866}
@@ -798,6 +821,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1294582014}
   m_RootOrder: 1
@@ -974,6 +998,7 @@ Canvas:
   m_OverrideSorting: 0
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
   m_AdditionalShaderChannelsFlag: 25
   m_SortingLayerID: 0
   m_SortingOrder: 0
@@ -988,6 +1013,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 41935981}
   m_Father: {fileID: 0}
@@ -1028,6 +1054,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1294582014}
   m_RootOrder: 6
@@ -1109,6 +1136,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1294582014}
   m_RootOrder: 8
@@ -1191,6 +1219,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1294582014}
   m_Father: {fileID: 0}
@@ -1241,6 +1270,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1294582014}
   m_RootOrder: 4

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Spans/CustomStartAndEndTime.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Spans/CustomStartAndEndTime.cs
@@ -1,0 +1,24 @@
+using System.Collections;
+using System.Collections.Generic;
+using BugsnagUnityPerformance;
+using UnityEngine;
+
+public class CustomStartAndEndTime : Scenario
+{
+
+    public override void PrepareConfig(string apiKey, string host)
+    {
+        base.PrepareConfig(apiKey, host);
+        SetMaxBatchSize(1);
+    }
+
+    public override void Run()
+    {
+        base.Run();
+        BugsnagPerformance.StartSpan("CustomStartAndEndTime",
+            new SpanOptions {StartTime = new System.DateTimeOffset(1985,1,1,1,1,1,System.TimeSpan.Zero)})
+            .End(new System.DateTimeOffset(1986, 1, 1, 1, 1, 1, System.TimeSpan.Zero));
+    }
+
+    
+}

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Spans/CustomStartAndEndTime.cs.meta
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Spans/CustomStartAndEndTime.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b1acdfac80082464180a997600222189
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -57,3 +57,10 @@ Feature: Manual creation of spans
     * the trace payload field "resourceSpans.0.resource" string attribute "device.manufacturer" exists
     * the trace payload field "resourceSpans.0.resource" string attribute "host.arch" exists
     * the trace payload field "resourceSpans.0.resource" string attribute "bugsnag.app.bundle_version" exists
+
+ Scenario: Custom timings
+    When I run the game in the "CustomStartAndEndTime" state
+    And I wait for 1 span
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "CustomStartAndEndTime"
+    * every span field "startTimeUnixNano" equals "473389261000000000"
+    * every span field "endTimeUnixNano" equals "504925261000000000"


### PR DESCRIPTION
## Goal

allowing a custom span end time was overlooked in the original implementation.

## Changeset

Allow setting custom end time in the `Span.End()` and `Span.EndNetworkSpan()` methods

## Testing

Added e2e tests