### PR TITLE
PLAT-12127 add traceid to error events

### DIFF
--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformance.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformance.cs
@@ -382,5 +382,34 @@ namespace BugsnagUnityPerformance
             }
         }
 
+        [Serializable]
+        private class SpanContextTransfer
+        {
+            public string spanId;
+            public string traceId;
+            public SpanContextTransfer(string spanId, string traceId)
+            {
+                this.spanId = spanId;
+                this.traceId = traceId;
+            }
+        } 
+
+        internal static string GetCurrentContextInternal()
+        {
+            var context = GetCurrentSpanContext();
+            if (context != null)
+            {
+                var transferClass = new SpanContextTransfer(context.SpanId, context.TraceId);
+                var json = JsonUtility.ToJson(transferClass);
+                return json;
+            }
+            return null;
+        }
+
+        public static ISpanContext GetCurrentSpanContext()
+        {
+            return _sharedInstance._spanFactory.GetCurrentContext();
+        }
+
     }
 }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformance.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformance.cs
@@ -361,6 +361,11 @@ namespace BugsnagUnityPerformance
             }
         }
 
+        public static ISpanContext GetCurrentSpanContext()
+        {
+            return _sharedInstance._spanFactory.GetCurrentContext();
+        }
+
         public static void ReportAppStarted()
         {
             AppStartHandler.ReportAppStarted();
@@ -383,33 +388,30 @@ namespace BugsnagUnityPerformance
         }
 
         [Serializable]
-        private class SpanContextTransfer
+        private class PerformanceState
         {
-            public string spanId;
-            public string traceId;
-            public SpanContextTransfer(string spanId, string traceId)
+            public string currentContextSpanId;
+            public string currentContextTraceId;
+            public PerformanceState(string currentContextSpanId, string currentContextTraceId)
             {
-                this.spanId = spanId;
-                this.traceId = traceId;
+                this.currentContextSpanId = currentContextSpanId;
+                this.currentContextTraceId = currentContextTraceId;
             }
         } 
 
-        internal static string GetCurrentContextInternal()
+        internal static string GetPerformanceState()
         {
             var context = GetCurrentSpanContext();
             if (context != null)
             {
-                var transferClass = new SpanContextTransfer(context.SpanId, context.TraceId);
-                var json = JsonUtility.ToJson(transferClass);
+                var performanceState = new PerformanceState(context.SpanId, context.TraceId);
+                var json = JsonUtility.ToJson(performanceState);
                 return json;
             }
             return null;
         }
 
-        public static ISpanContext GetCurrentSpanContext()
-        {
-            return _sharedInstance._spanFactory.GetCurrentContext();
-        }
+
 
     }
 }


### PR DESCRIPTION
## NOTE

This PR is part of work connected to the Unity Notifier, the sister PR can be found here: https://github.com/bugsnag/bugsnag-unity/pull/801

Please do not review this PR without also reviewing the other

## Goal

Provide access to the unity notifier so that when a C# layer error occurs, it can get the current span context and include it in the event report.

## Changeset

Added GetPerformanceState method in BugsnagPerformance that can be accessed via reflection.

## Testing

Manually tested
E2E Tests will be added in a later task