### PR TITLE
add notifier to fixture [full ci]

### DIFF
--- a/features/fixtures/mazerunner/Packages/manifest.json
+++ b/features/fixtures/mazerunner/Packages/manifest.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "com.bugsnag.unitynotifier": "https://github.com/bugsnag/bugsnag-unity-upm.git",
     "com.unity.collab-proxy": "2.0.5",
     "com.unity.ide.rider": "1.2.1",
     "com.unity.ide.visualstudio": "2.0.12",


### PR DESCRIPTION
## Goal

Add the Bugsnag Unity Notifier to the performance test fixture.
This is to pave the way for testing interconnected features and to test that both SDKs can be imported without issue.

## Testing

Successful build of the fixture prooves no import conflicts or resulting issues