### PR TITLE
PLAT-12235 fix for connection type check on main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Bug Fixes
+
+- Fixed issue where creating a span in a background thread caused an exception (mono or IL2CPP Dev builds only) [#117](https://github.com/bugsnag/bugsnag-unity-performance/pull/117)
+
 ## v1.4.0 (2024-30-05)
 
 ### Additions


### PR DESCRIPTION
## Goal

Calling Application.internetReachability from a background thread is not allowed and throws an exception.

NOTE: This bug was not caught by our E2E testing because IL2CPP strips out the thread safety check in release builds.

## Changeset

Changed to a polling method that checks the connection status once a second.

## Testing

Covered by existing E2E tests