### PR TITLE
Release v1.4.1

### DIFF
--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Version.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Version.cs
@@ -3,6 +3,6 @@
     internal static class Version
     {
         //TODO set this using sed or something in the release automation task
-        public const string VersionString = "1.4.0";
+        public const string VersionString = "1.4.1";
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## TBD
+## v1.4.1 (2024-11-06)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Bug Fixes
+
+- Fixed issue where creating a span in a background thread caused an exception (mono or IL2CPP Dev builds only) [#117](https://github.com/bugsnag/bugsnag-unity-performance/pull/117)
+
 ## v1.4.0 (2024-30-05)
 
 ### Additions


### PR DESCRIPTION
## v1.4.1 (2024-11-06)

### Bug Fixes

- Fixed issue where creating a span in a background thread caused an exception (mono or IL2CPP Dev builds only) [#117](https://github.com/bugsnag/bugsnag-unity-performance/pull/117)