### PR TITLE
PLAT-12362 fix issue with span parentage when MakeCurrentContext is false

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ features/fixtures/minimalapp/Packages
 features/fixtures/minimalapp/minimal_with_xcode
 features/fixtures/minimalapp/minimal_without_xcode
 features/fixtures/mazerunner/mazerunner_macos_BackUpThisFolder_ButDontShipItWithYourGame
+BugsnagPerformance/.vscode

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/SpanFactory.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/SpanFactory.cs
@@ -72,27 +72,29 @@ namespace BugsnagUnityPerformance
 
         private Span CreateSpan(string name, SpanKind kind, SpanOptions spanOptions)
         {
-                        
-            if (spanOptions.ParentContext != null)
-            {
-                AddToContextStack(spanOptions.ParentContext);
-            }
-
-            string traceId = string.Empty;
             string parentSpanId = null;
+            string traceId;
             string spanId = GetNewSpanId();
 
-            var existingContext = GetCurrentContext();
-            if (existingContext != null)
+            if (spanOptions.ParentContext != null)
             {
-                traceId = existingContext.TraceId;
-                parentSpanId = existingContext.SpanId;
+                traceId = spanOptions.ParentContext.TraceId;
+                parentSpanId = spanOptions.ParentContext.SpanId;
             }
             else
             {
-                traceId = GetNewTraceId();
+                var existingContext = GetCurrentContext();
+                if (existingContext != null)
+                {
+                    traceId = existingContext.TraceId;
+                    parentSpanId = existingContext.SpanId;
+                }
+                else
+                {
+                    traceId = GetNewTraceId();
+                }
             }
-
+           
             var newSpan = new Span(name, kind, spanId, traceId, parentSpanId, spanOptions.StartTime, spanOptions.IsFirstClass, _onSpanEnd);
 
             if (spanOptions.MakeCurrentContext)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Bug Fixes
+
+- Fix an issue where spans with MakeCurrentContext set to false and passed as a parent would be added to the context stack. [#122](https://github.com/bugsnag/bugsnag-unity-performance/pull/122)
+
 ## v1.4.1 (2024-11-06)
 
 ### Bug Fixes

--- a/features/fixtures/mazerunner/Assets/Scenes/MainScene.unity
+++ b/features/fixtures/mazerunner/Assets/Scenes/MainScene.unity
@@ -389,6 +389,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 94f564ad5b05945d9ac6e530f5873bfe, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ShouldStartNotifier: 0
 --- !u!1 &320782971
 GameObject:
   m_ObjectHideFlags: 0
@@ -1133,6 +1134,7 @@ GameObject:
   - component: {fileID: 1609554508}
   - component: {fileID: 1609554509}
   - component: {fileID: 1609554510}
+  - component: {fileID: 1609554511}
   m_Layer: 0
   m_Name: NestedSpans
   m_TagString: Untagged
@@ -1220,6 +1222,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ShouldStartNotifier: 0
+--- !u!114 &1609554511
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1609554504}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3d7da4daac88a4bb2be4043564a67ac0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2053587485
 GameObject:
   m_ObjectHideFlags: 0

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/NestedSpans/PassContextWithMakeContextFalse.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/NestedSpans/PassContextWithMakeContextFalse.cs
@@ -1,0 +1,23 @@
+using System.Collections;
+using System.Collections.Generic;
+using BugsnagUnityPerformance;
+using UnityEngine;
+
+public class PassContextWithMakeContextFalse : Scenario
+{
+    public override void PreparePerformanceConfig(string apiKey, string host)
+    {
+        base.PreparePerformanceConfig(apiKey, host);
+        SetMaxBatchSize(3);
+    }
+
+    public override void Run()
+    {
+        var span1 = BugsnagPerformance.StartSpan("span1", new SpanOptions { MakeCurrentContext = false });
+        var span2 = BugsnagPerformance.StartSpan("span2", new SpanOptions { ParentContext = span1 });
+        span2.End();
+        var span3 = BugsnagPerformance.StartSpan("span3");
+        span3.End();
+        span1.End();
+    }
+}

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/NestedSpans/PassContextWithMakeContextFalse.cs.meta
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/NestedSpans/PassContextWithMakeContextFalse.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3d7da4daac88a4bb2be4043564a67ac0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/nested_spans.feature
+++ b/features/nested_spans.feature
@@ -85,4 +85,21 @@ Feature: Nested Spans
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.2" bool attribute "bugsnag.span.first_class" is false
 
 
+  Scenario: Pass Context With Make Context False
+    When I run the game in the "PassContextWithMakeContextFalse" state
+    And I wait for 3 spans
+    Then the trace Bugsnag-Integrity header is valid
+    And the trace "Bugsnag-Api-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * the trace "Bugsnag-Span-Sampling" header equals "1:3"
+
+    * the span named "span1" exists
+    * the span named "span2" exists
+    * the span named "span3" exists
+
+    * the span named "span1" has no parent
+
+    * the span named "span1" is the parent of the span named "span2"
+
+    * the span named "span3" has no parent
 


### PR DESCRIPTION
## Goal

Fix a bug where if a span with MakeCurrentContext set to false was passed as a parent then it would be added to the context stack

## Changeset

Now spans passed as parents will only be assigned as the parent for that particular span.

## Testing

Added a new E2E test to cover this scenario