### PR TITLE
PLAT-12568 correct TracePropagationUrls

### DIFF
--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformance.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformance.cs
@@ -29,7 +29,7 @@ namespace BugsnagUnityPerformance
         private PValueUpdater _pValueUpdater;
         private static List<Span> _potentiallyOpenSpans = new List<Span>();
         private Func<BugsnagNetworkRequestInfo, BugsnagNetworkRequestInfo> _networkRequestCallback;
-        private static string[] _tracePropagationUrlMatchPatterns;
+        private static Regex[] _tracePropagationUrlMatchPatterns;
 
 
         public static void Start(PerformanceConfiguration configuration)
@@ -46,9 +46,9 @@ namespace BugsnagUnityPerformance
                 }
                 IsStarted = true;
             }
-            if (configuration.TracePropagationUrlMatchPatterns != null)
+            if (configuration.TracePropagationUrls != null)
             {
-                _tracePropagationUrlMatchPatterns = configuration.TracePropagationUrlMatchPatterns.ToArray();
+                _tracePropagationUrlMatchPatterns = configuration.TracePropagationUrls.ToArray();
             }
             ValidateApiKey(configuration.ApiKey);
             if (ReleaseStageEnabled(configuration))
@@ -305,7 +305,7 @@ namespace BugsnagUnityPerformance
             }
             foreach (var pattern in _tracePropagationUrlMatchPatterns)
             {
-                if (Regex.IsMatch(url, pattern))
+                if (pattern.IsMatch(url))
                 {
                     return true;
                 }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using UnityEngine;
 
 namespace BugsnagUnityPerformance
@@ -36,8 +37,7 @@ namespace BugsnagUnityPerformance
 
         public string ReleaseStage = Debug.isDebugBuild ? "development" : "production";
 
-        public String[] TracePropagationUrlMatchPatterns;
-
+        public Regex[] TracePropagationUrls;
 
         public void AddOnSpanEnd(Func<Span, bool> callback)
         {

--- a/BugsnagPerformance/Assets/UnitTests/ConfigurationTests.cs
+++ b/BugsnagPerformance/Assets/UnitTests/ConfigurationTests.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 using UnityEngine.TestTools;
 using BugsnagUnityPerformance;
 using System;
+using System.Text.RegularExpressions;
 
 namespace Tests
 {
@@ -44,6 +45,31 @@ namespace Tests
             span.End(CustomEndTime);
             Assert.AreEqual(span.StartTime, CustomStartTime);
             Assert.AreEqual(span.EndTime, CustomEndTime);
+        }
+
+        [Test]
+        public void TracePropagationUrlsTest()
+        {
+            var config = new PerformanceConfiguration(VALID_API_KEY);
+
+            Regex pattern1 = new Regex("https://example.com/.*");
+            Regex pattern2 = new Regex("https://anotherexample.com/.*");
+
+            config.TracePropagationUrls = new[] { pattern1, pattern2 };
+
+            Assert.AreEqual(2, config.TracePropagationUrls.Length);
+            Assert.AreEqual(pattern1.ToString(), config.TracePropagationUrls[0].ToString());
+            Assert.AreEqual(pattern2.ToString(), config.TracePropagationUrls[1].ToString());
+
+            string matchingUrl1 = "https://example.com/path/to/resource";
+            string nonMatchingUrl1 = "https://notexample.com/path";
+            string matchingUrl2 = "https://anotherexample.com/another/path";
+            string nonMatchingUrl2 = "https://example.com/not/anotherexample";
+
+            Assert.IsTrue(config.TracePropagationUrls[0].IsMatch(matchingUrl1));
+            Assert.IsFalse(config.TracePropagationUrls[0].IsMatch(nonMatchingUrl1));
+            Assert.IsTrue(config.TracePropagationUrls[1].IsMatch(matchingUrl2));
+            Assert.IsFalse(config.TracePropagationUrls[1].IsMatch(nonMatchingUrl2));
         }
 
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Allow setting custom span attributes. [#124](https://github.com/bugsnag/bugsnag-unity-performance/pull/124)
 
+### Bug Fixes
+
+- Fix an issue where TracePropagationUrls was incorrectly named and typed. [#126](https://github.com/bugsnag/bugsnag-unity-performance/pull/126)
+
 ## v1.4.2 (2024-06-27)
 
 ### Bug Fixes

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Network/TraceParentConfig.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Network/TraceParentConfig.cs
@@ -2,13 +2,17 @@ using System.Collections;
 using System.Collections.Generic;
 using BugsnagNetworking;
 using UnityEngine;
+using System.Text.RegularExpressions;
 
 public class TraceParentConfig : Scenario
 {
     public override void PreparePerformanceConfig(string apiKey, string host)
     {
         base.PreparePerformanceConfig(apiKey, host);
-        Configuration.TracePropagationUrlMatchPatterns = new string[]{ "dosend" };
+        Configuration.TracePropagationUrls = new Regex[]
+        {
+            new Regex(".*dosend.*")
+        };
     }
 
     public override void Run()


### PR DESCRIPTION
## Goal

The config value `TracePropagationUrls` was incorrectly named and typed.

It should be a Regex Pattern collection.

## Testing

Added unit test and covered by existing E2E tests