### PR TITLE
PLAT-10952 convert span refs to weak refs to avoid memory leaks

### DIFF
--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Sampler.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Sampler.cs
@@ -1,8 +1,4 @@
-﻿
-
-using UnityEngine;
-
-namespace BugsnagUnityPerformance
+﻿namespace BugsnagUnityPerformance
 {
     public class Sampler : IPhasedStartup
     {
@@ -49,10 +45,9 @@ namespace BugsnagUnityPerformance
         public bool Sampled(Span span, bool shouldAddAttribute = true)
         {
             var p = Probability;
-            Debug.Log("Probability: " + p);
             var isSampled = IsSampled(span, GetUpperBound(p));
 #if BUGSNAG_DEBUG
-            Logger.I(string.Format("Span {0} is sampled: {1} with p value: {2}",span.Name,isSampled,p));
+            Logger.I(string.Format("Span {0} is sampled: {1} with p value: {2}", span.Name, isSampled, p));
 #endif
             if (isSampled && shouldAddAttribute)
             {
@@ -65,7 +60,6 @@ namespace BugsnagUnityPerformance
         private bool IsSampled(Span span, ulong upperBound)
         {
             var traceId = ulong.Parse(span.TraceId.Substring(0, 16), System.Globalization.NumberStyles.HexNumber);
-            Debug.Log("traceId: " + traceId + " upperBound: " + upperBound);
             return traceId <= upperBound;
         }
 

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Sampler.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Sampler.cs
@@ -1,4 +1,7 @@
 ﻿
+
+using UnityEngine;
+
 namespace BugsnagUnityPerformance
 {
     public class Sampler : IPhasedStartup
@@ -46,6 +49,7 @@ namespace BugsnagUnityPerformance
         public bool Sampled(Span span, bool shouldAddAttribute = true)
         {
             var p = Probability;
+            Debug.Log("Probability: " + p);
             var isSampled = IsSampled(span, GetUpperBound(p));
 #if BUGSNAG_DEBUG
             Logger.I(string.Format("Span {0} is sampled: {1} with p value: {2}",span.Name,isSampled,p));
@@ -61,6 +65,7 @@ namespace BugsnagUnityPerformance
         private bool IsSampled(Span span, ulong upperBound)
         {
             var traceId = ulong.Parse(span.TraceId.Substring(0, 16), System.Globalization.NumberStyles.HexNumber);
+            Debug.Log("traceId: " + traceId + " upperBound: " + upperBound);
             return traceId <= upperBound;
         }
 

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Tracer.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Tracer.cs
@@ -99,6 +99,7 @@ namespace BugsnagUnityPerformance
 
         public void OnSpanEnd(Span span)
         {
+            Debug.Log("OnSpanEnd: " + span.Name);
             var weakSpan = new WeakReference<Span>(span);
 
             if (!_started)
@@ -143,6 +144,7 @@ namespace BugsnagUnityPerformance
 
         private void Sample(Span span)
         {
+            Debug.Log("Sampling span: " + span.Name);
             if (_sampler.Sampled(span))
             {
                 RunOnEndCallbacks(span);

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Tracer.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Tracer.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using UnityEngine;
 
@@ -99,7 +98,6 @@ namespace BugsnagUnityPerformance
 
         public void OnSpanEnd(Span span)
         {
-            Debug.Log("OnSpanEnd: " + span.Name);
             var weakSpan = new WeakReference<Span>(span);
 
             if (!_started)
@@ -144,18 +142,11 @@ namespace BugsnagUnityPerformance
 
         private void Sample(Span span)
         {
-            Debug.Log("Sampling span: " + span.Name);
             if (_sampler.Sampled(span))
             {
-                Debug.Log("Running OnEndCallbacks");
-
                 RunOnEndCallbacks(span);
-                                Debug.Log("OnEndCallbacks complete");
-
                 if (!span.WasDiscarded)
                 {
-                                    Debug.Log("Adding span to queue");
-
                     AddSpanToQueue(span);
                 }
             }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Tracer.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Tracer.cs
@@ -98,13 +98,11 @@ namespace BugsnagUnityPerformance
 
         public void OnSpanEnd(Span span)
         {
-            var weakSpan = new WeakReference<Span>(span);
-
             if (!_started)
             {
                 lock (_prestartLock)
                 {
-                    _preStartSpans.Add(weakSpan);
+                    _preStartSpans.Add(new WeakReference<Span>(span));
                 }
                 return;
             }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Tracer.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Tracer.cs
@@ -147,9 +147,15 @@ namespace BugsnagUnityPerformance
             Debug.Log("Sampling span: " + span.Name);
             if (_sampler.Sampled(span))
             {
+                Debug.Log("Running OnEndCallbacks");
+
                 RunOnEndCallbacks(span);
+                                Debug.Log("OnEndCallbacks complete");
+
                 if (!span.WasDiscarded)
                 {
+                                    Debug.Log("Adding span to queue");
+
                     AddSpanToQueue(span);
                 }
             }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformance.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformance.cs
@@ -42,9 +42,11 @@ namespace BugsnagUnityPerformance
 
         public static void Start(PerformanceConfiguration configuration)
         {
+#if BUGSNAG_DEBUG
+            Logger.I("BugsnagPerformance.Start called");
+#endif
             lock (_startLock)
             {
-
                 if (IsStarted)
                 {
                     Debug.LogWarning(ALREADY_STARTED_WARNING);
@@ -68,6 +70,9 @@ namespace BugsnagUnityPerformance
                 });
                 _sharedInstance.Configure(configuration);
                 _sharedInstance.Start();
+#if BUGSNAG_DEBUG
+                Logger.I("Start Complete");
+#endif
             }
         }
 
@@ -78,10 +83,10 @@ namespace BugsnagUnityPerformance
 
         private static void ValidateApiKey(string apiKey)
         {
-            if (!System.Text.RegularExpressions.Regex.IsMatch(apiKey, @"\A\b[0-9a-fA-F]+\b\Z") ||
+            if (!Regex.IsMatch(apiKey, @"\A\b[0-9a-fA-F]+\b\Z") ||
                 apiKey.Length != 32)
             {
-                throw new System.Exception($"Invalid Bugsnag Performance configuration. apiKey should be a 32-character hexademical string, got {apiKey} ");
+                throw new Exception($"Invalid Bugsnag Performance configuration. apiKey should be a 32-character hexademical string, got {apiKey} ");
             }
         }
 
@@ -148,6 +153,7 @@ namespace BugsnagUnityPerformance
 
         private void Start()
         {
+            // The ordering of Start() must be carefully curated.
             _cacheManager.Start();
             _persistentState.Start();
             _delivery.Start();
@@ -221,7 +227,7 @@ namespace BugsnagUnityPerformance
             }
         }
 
-         private Span GetSceneLoadSpan(Scene scene)
+        private Span GetSceneLoadSpan(Scene scene)
         {
             if (_sceneLoadSpans.ContainsKey(scene.name))
             {

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformance.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformance.cs
@@ -37,7 +37,7 @@ namespace BugsnagUnityPerformance
 
         internal class SceneLoadSpanContainer
         {
-            public List<WeakReference<Span>> Spans = new List<WeakReference<Span>>();
+            public List<Span> Spans = new List<Span>();
         }
 
         public static void Start(PerformanceConfiguration configuration)
@@ -209,7 +209,7 @@ namespace BugsnagUnityPerformance
                 var spanLoadInstance = new SceneLoadSpanContainer();
                 _sceneLoadSpans.Add(sceneName, spanLoadInstance);
             }
-            _sceneLoadSpans[sceneName].Spans.Add(new WeakReference<Span>(_spanFactory.CreateAutomaticSceneLoadSpan()));
+            _sceneLoadSpans[sceneName].Spans.Add(_spanFactory.CreateAutomaticSceneLoadSpan());
         }
 
         private void OnSceneLoadEnd(Scene scene, LoadSceneMode mode)
@@ -221,18 +221,16 @@ namespace BugsnagUnityPerformance
             }
         }
 
-        private Span GetSceneLoadSpan(Scene scene)
+         private Span GetSceneLoadSpan(Scene scene)
         {
             if (_sceneLoadSpans.ContainsKey(scene.name))
             {
                 var container = _sceneLoadSpans[scene.name];
-                foreach (var weakRef in container.Spans)
+                if (container.Spans.Count > 0)
                 {
-                    if (weakRef.TryGetTarget(out var span))
-                    {
-                        container.Spans.Remove(weakRef);
-                        return span;
-                    }
+                    var span = container.Spans[0];
+                    container.Spans.RemoveAt(0);
+                    return span;
                 }
             }
             return null;

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformance.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformance.cs
@@ -175,6 +175,10 @@ namespace BugsnagUnityPerformance
             {
                 _potentiallyOpenSpans.RemoveAll(wr => wr.TryGetTarget(out var s) && s == span);
             }
+            if (span.WasDiscarded)
+            {
+                return;
+            }
             _tracer.OnSpanEnd(span);
         }
 

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformance.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformance.cs
@@ -17,7 +17,7 @@ namespace BugsnagUnityPerformance
         private static object _startLock = new object();
         internal static bool IsStarted = false;
         private object _startSpanLock = new object();
-        private object _networkSpansLock = new object();
+        private static object _networkSpansLock = new object();
         private SpanFactory _spanFactory;
         private CacheManager _cacheManager;
         private Delivery _delivery;
@@ -30,7 +30,7 @@ namespace BugsnagUnityPerformance
         private static List<WeakReference<Span>> _potentiallyOpenSpans = new List<WeakReference<Span>>();
         private Func<BugsnagNetworkRequestInfo, BugsnagNetworkRequestInfo> _networkRequestCallback;
 
-        private Dictionary<WeakReference<BugsnagUnityWebRequest>, Span> _networkSpans = new Dictionary<WeakReference<BugsnagUnityWebRequest>, Span>();
+        private static Dictionary<WeakReference<BugsnagUnityWebRequest>, Span> _networkSpans = new Dictionary<WeakReference<BugsnagUnityWebRequest>, Span>();
 
         private static Regex[] _tracePropagationUrlMatchPatterns;
 
@@ -296,7 +296,6 @@ namespace BugsnagUnityPerformance
                 }
                 request.SetRequestHeader("traceparent", BuildTraceParentHeader(traceId, parentId, sampled));
             }
-            CleanUpCollectedRequests();
         }
 
         private static bool ShouldAddTraceParentHeader(string url)
@@ -362,10 +361,9 @@ namespace BugsnagUnityPerformance
                     _networkSpans.Remove(networkSpanKey);
                 }
             }
-            CleanUpCollectedRequests();
         }
 
-        private void CleanUpCollectedRequests()
+        private static void CleanUpCollectedRequests()
         {
             List<WeakReference<BugsnagUnityWebRequest>> keysToRemove = new List<WeakReference<BugsnagUnityWebRequest>>();
 
@@ -413,6 +411,7 @@ namespace BugsnagUnityPerformance
 
         internal static void AppBackgrounded()
         {
+            CleanUpCollectedRequests();
             CancelAllOpenSpans();
         }
 

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/Span.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/Span.cs
@@ -70,7 +70,6 @@ namespace BugsnagUnityPerformance
                     return;
                 }
                 Ended = true;
-                _onSpanEnd(this);
             }
         }
 

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/Span.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/Span.cs
@@ -65,10 +65,6 @@ namespace BugsnagUnityPerformance
             lock (_endLock)
             {
                 WasDiscarded = true;
-                if (Ended)
-                {
-                    return;
-                }
                 Ended = true;
             }
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Additions
 
 - Allow setting custom span attributes. [#124](https://github.com/bugsnag/bugsnag-unity-performance/pull/124)
+- Changed internal Span references to WeakReferences to avoid memory leaks. [#127](https://github.com/bugsnag/bugsnag-unity-performance/pull/127)
 
 ### Bug Fixes
 

--- a/features/correlation.feature
+++ b/features/correlation.feature
@@ -36,10 +36,11 @@ Feature: Manual creation of spans
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" is stored as the value "background_span_id"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" is stored as the value "background_trace_id"
 
+    And I discard the oldest trace
 
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.name" equals "Span From Main Thread"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.spanId" is stored as the value "main_span_id"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.traceId" is stored as the value "main_trace_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "Span From Main Thread"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" is stored as the value "main_span_id"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" is stored as the value "main_trace_id"
 
     * I sort the errors by the payload field "events.0.exceptions.0.message"
 

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Configuration/CustomReleaseStage.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Configuration/CustomReleaseStage.cs
@@ -3,24 +3,17 @@
 public class CustomReleaseStage : Scenario
 {
 
-    private Span _span;
-
     public override void PreparePerformanceConfig(string apiKey, string host)
     {
         base.PreparePerformanceConfig(apiKey, host);
         Configuration.ReleaseStage = "CustomReleaseStage";
-        SetMaxBatchAgeSeconds(1);
+        SetMaxBatchSize(1);
     }
 
     public override void Run()
     {
         base.Run();
-        _span = BugsnagPerformance.StartSpan("CustomReleaseStage");
-        Invoke("EndSpan", 1);
+        BugsnagPerformance.StartSpan("CustomReleaseStage").End();
     }
 
-    private void EndSpan()
-    {
-        _span.End();
-    }
 }

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Configuration/DisabledReleaseStages.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Configuration/DisabledReleaseStages.cs
@@ -13,18 +13,13 @@ public class DisabledReleaseStages : Scenario
         base.PreparePerformanceConfig(apiKey, host);
         Configuration.ReleaseStage = "EnabledReleaseStages";
         Configuration.EnabledReleaseStages = new[] { "DisabledReleaseStages" };
-        SetMaxBatchAgeSeconds(1);
+        SetMaxBatchSize(1);
     }
 
     public override void Run()
     {
         base.Run();
-        _span = BugsnagPerformance.StartSpan("DisabledReleaseStages");
-        Invoke("EndSpan", 1);
+        BugsnagPerformance.StartSpan("DisabledReleaseStages").End();
     }
 
-    private void EndSpan()
-    {
-        _span.End();
-    }
 }

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Configuration/EmptyReleaseStages.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Configuration/EmptyReleaseStages.cs
@@ -6,24 +6,17 @@ using BugsnagUnityPerformance;
 public class EmptyReleaseStages : Scenario
 {
 
-    private Span _span;
-
     public override void PreparePerformanceConfig(string apiKey, string host)
     {
         base.PreparePerformanceConfig(apiKey, host);
         Configuration.EnabledReleaseStages = new string[] {};
-        SetMaxBatchAgeSeconds(1);
+        SetMaxBatchSize(1);
     }
 
     public override void Run()
     {
         base.Run();
-        _span = BugsnagPerformance.StartSpan("EmptyReleaseStages");
-        Invoke("EndSpan", 1);
+        BugsnagPerformance.StartSpan("EmptyReleaseStages").End();
     }
 
-    private void EndSpan()
-    {
-        _span.End();
-    }
 }

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Configuration/EnabledReleaseStages.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Configuration/EnabledReleaseStages.cs
@@ -6,25 +6,18 @@ using UnityEngine;
 public class EnabledReleaseStages : Scenario
 {
 
-    private Span _span;
-
     public override void PreparePerformanceConfig(string apiKey, string host)
     {
         base.PreparePerformanceConfig(apiKey, host);
         Configuration.ReleaseStage = "EnabledReleaseStages";
         Configuration.EnabledReleaseStages = new[] { "EnabledReleaseStages" };
-        SetMaxBatchAgeSeconds(1);
+        SetMaxBatchSize(1);
     }
 
     public override void Run()
     {
         base.Run();
-        _span = BugsnagPerformance.StartSpan("EnabledReleaseStages");
-        Invoke("EndSpan", 1);
+        BugsnagPerformance.StartSpan("EnabledReleaseStages").End();
     }
 
-    private void EndSpan()
-    {
-        _span.End();
-    }
 }

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Correlation/CorrelationOnDifferentThread.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Correlation/CorrelationOnDifferentThread.cs
@@ -16,15 +16,17 @@ public class CorrelationOnDifferentThread : Scenario
     public override void Run()
     {
         var span = BugsnagPerformance.StartSpan("Span From Main Thread");
-
+        var finished = false;
         Thread newThread = new Thread(new ThreadStart(()=>
         {
             var newThreadSpan = BugsnagPerformance.StartSpan("Span From Background Thread");
             Bugsnag.Notify(new System.Exception("Event From Background Thread"));
             newThreadSpan.End();
+            finished = true;
         }));
         
         newThread.Start();
+        while(!finished){}
         Bugsnag.Notify(new System.Exception("Event From Main Thread"));
         span.End();
     }

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Correlation/CorrelationOnDifferentThread.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Correlation/CorrelationOnDifferentThread.cs
@@ -9,7 +9,7 @@ public class CorrelationOnDifferentThread : Scenario
     public override void PreparePerformanceConfig(string apiKey, string host)
     {
         base.PreparePerformanceConfig(apiKey, host);
-        SetMaxBatchSize(2);
+        SetMaxBatchSize(1);
         ShouldStartNotifier = true;
     }
 
@@ -19,9 +19,9 @@ public class CorrelationOnDifferentThread : Scenario
 
         Thread newThread = new Thread(new ThreadStart(()=>
         {
-            var span = BugsnagPerformance.StartSpan("Span From Background Thread");
+            var newThreadSpan = BugsnagPerformance.StartSpan("Span From Background Thread");
             Bugsnag.Notify(new System.Exception("Event From Background Thread"));
-            span.End();
+            newThreadSpan.End();
         }));
         
         newThread.Start();

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Network/ManualNetworkSpan.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Network/ManualNetworkSpan.cs
@@ -5,24 +5,16 @@ using UnityEngine;
 
 public class ManualNetworkSpan : Scenario
 {
-
-    private Span _span;
-
     public override void PreparePerformanceConfig(string apiKey, string host)
     {
         base.PreparePerformanceConfig(apiKey, host);
-        SetMaxBatchAgeSeconds(1);
+        SetMaxBatchSize(1);
     }
 
     public override void Run()
     {
         base.Run();
-        _span = BugsnagPerformance.StartNetworkSpan(Main.MazeHost, HttpVerb.PATCH);
-        Invoke("EndSpan", 1);
+        BugsnagPerformance.StartNetworkSpan(Main.MazeHost, HttpVerb.PATCH).EndNetworkSpan(202,123,321);;
     }
 
-    private void EndSpan()
-    {
-        _span.EndNetworkSpan(202,123,321);
-    }
 }

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Persistence/PValueUpdate.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Persistence/PValueUpdate.cs
@@ -9,7 +9,7 @@ public class PValueUpdate : Scenario
     public override void PreparePerformanceConfig(string apiKey, string host)
     {
         base.PreparePerformanceConfig(apiKey, host);
-        SetMaxBatchAgeSeconds(1);
+        SetMaxBatchSize(1);
     }
 
     public override void Run()

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/SceneLoad/ManualSceneSpan.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/SceneLoad/ManualSceneSpan.cs
@@ -6,23 +6,16 @@ using UnityEngine;
 public class ManualSceneSpan : Scenario
 {
 
-    private Span _span;
-
     public override void PreparePerformanceConfig(string apiKey, string host)
     {
         base.PreparePerformanceConfig(apiKey, host);
-        SetMaxBatchAgeSeconds(1);
+        SetMaxBatchSize(1);
     }
 
     public override void Run()
     {
         base.Run();
-        _span = BugsnagPerformance.StartSceneSpan("ManualSceneSpan");
-        Invoke("EndSpan", 1);
+        BugsnagPerformance.StartSceneSpan("ManualSceneSpan").End();
     }
 
-    private void EndSpan()
-    {
-        _span.End();
-    }
 }

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Spans/ConfiguredSamplingRate0.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Spans/ConfiguredSamplingRate0.cs
@@ -12,7 +12,7 @@ public class ConfiguredSamplingRate0 : Scenario
     {
         base.PreparePerformanceConfig(apiKey, host);
         SetSamplingProbability(0);
-        SetMaxBatchAgeSeconds(1);
+        SetMaxBatchSize(1);
     }
 
     public override void Run()

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Spans/ConfiguredSamplingRate1.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Spans/ConfiguredSamplingRate1.cs
@@ -8,7 +8,6 @@ public class ConfiguredSamplingRate1 : Scenario
     public override void PreparePerformanceConfig(string apiKey, string host)
     {
         base.PreparePerformanceConfig(apiKey, host);
-        Configuration.AutoInstrumentAppStart = AutoInstrumentAppStartSetting.OFF;
         SetMaxBatchSize(4);
     }
 
@@ -19,6 +18,5 @@ public class ConfiguredSamplingRate1 : Scenario
         BugsnagPerformance.StartSpan("ManualSpan2").End();
         BugsnagPerformance.StartSpan("ManualSpan3").End();
         BugsnagPerformance.StartSpan("ManualSpan4").End();
-        Debug.Log("ALL SPANS ENDED");
     }
 }

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Spans/ConfiguredSamplingRate1.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Spans/ConfiguredSamplingRate1.cs
@@ -8,7 +8,8 @@ public class ConfiguredSamplingRate1 : Scenario
     public override void PreparePerformanceConfig(string apiKey, string host)
     {
         base.PreparePerformanceConfig(apiKey, host);
-        SetMaxBatchAgeSeconds(1);
+        Configuration.AutoInstrumentAppStart = AutoInstrumentAppStartSetting.OFF;
+        SetMaxBatchSize(4);
     }
 
     public override void Run()
@@ -18,5 +19,6 @@ public class ConfiguredSamplingRate1 : Scenario
         BugsnagPerformance.StartSpan("ManualSpan2").End();
         BugsnagPerformance.StartSpan("ManualSpan3").End();
         BugsnagPerformance.StartSpan("ManualSpan4").End();
+        Debug.Log("ALL SPANS ENDED");
     }
 }

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Spans/ManualSpan.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Spans/ManualSpan.cs
@@ -6,23 +6,16 @@ using UnityEngine;
 public class ManualSpan : Scenario
 {
 
-    private Span _span;
-
     public override void PreparePerformanceConfig(string apiKey, string host)
     {
         base.PreparePerformanceConfig(apiKey, host);
-        SetMaxBatchAgeSeconds(1);
+        SetMaxBatchSize(1);
     }
 
     public override void Run()
     {
         base.Run();
-        _span = BugsnagPerformance.StartSpan("ManualSpan");
-        Invoke("EndSpan",1);
+        BugsnagPerformance.StartSpan("ManualSpan").End();
     }
 
-    private void EndSpan()
-    {
-        _span.End();
-    }
 }


### PR DESCRIPTION
## Goal

Convert span refs to weak refs to avoid memory leaks

## Changeset

- Convert the context stack in `SpanFactory.cs` to `Stack<WeakReference<ISpanContext>>`
- Convert `_preStartSpans` and `_finishedSpanQueue` in `Tracer.cs` to `Stack<WeakReference<ISpanContext>>`
- Fix bug in `Tracer.cs` where `OnEndCallbacks` ran twice on pre start spans
- Convert pending network spans collection to `Dictionary<WeakReference<BugsnagUnityWebRequest>, Span>`
- Converted multiple E2E tests that used time based batches to use batchsize instead to avoid race conditions
- Some code formatting refactor

### Changes to Span.Discard(), Span.End() and cleaning span collections in BugsnagPerformance.

Now that the collection BugsnagPerformance._potentiallyOpenSpans is a weak reference collection, it's no longer important to remove spans from it when they are ended. Because of this it is also no longer necessary to call the onSpanEnd delegate when a span is discarded. 

The discard method is now much simpler and more performant, as is the normal endSpan method.

_potentiallyOpenSpans and _networkSpans are now cleaned up whenever the app is backgrounded.

## Testing

Making sure nothing is broken by this change is covered by existing E2E tests. 
Garbage collection of forgotten about spans was tested manually.