### PR TITLE
PLAT-12557 add a fixed sampling probability configuration option

### DIFF
--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Delivery.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Delivery.cs
@@ -16,11 +16,9 @@ namespace BugsnagUnityPerformance
     {
         private string _endpoint;
         private string _apiKey;
-        private bool _probabilityOverride = false;
+        private bool _isFixedSamplingProbability = false;
         private OnProbabilityChanged _onProbabilityChanged;
-
         private bool _flushingCache;
-
         private ResourceModel _resourceModel;
         private CacheManager _cacheManager;
 
@@ -61,7 +59,7 @@ namespace BugsnagUnityPerformance
         {
             _endpoint = config.Endpoint;
             _apiKey = config.ApiKey;
-            _probabilityOverride = config.IsFixedSamplingProbability;
+            _isFixedSamplingProbability = config.IsFixedSamplingProbability;
         }
 
         public void Start()
@@ -71,7 +69,7 @@ namespace BugsnagUnityPerformance
 
         public void Deliver(List<Span> batch)
         {
-            var payload = new TracePayload(_resourceModel, batch, _probabilityOverride);
+            var payload = new TracePayload(_resourceModel, batch, _isFixedSamplingProbability);
             MainThreadDispatchBehaviour.Instance().Enqueue(PushToServer(payload, OnTraceDeliveryCompleted));
         }
 

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Delivery.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Delivery.cs
@@ -16,6 +16,7 @@ namespace BugsnagUnityPerformance
     {
         private string _endpoint;
         private string _apiKey;
+        private bool _probabilityOverride = false;
         private OnProbabilityChanged _onProbabilityChanged;
 
         private bool _flushingCache;
@@ -60,6 +61,7 @@ namespace BugsnagUnityPerformance
         {
             _endpoint = config.Endpoint;
             _apiKey = config.ApiKey;
+            _probabilityOverride = config.IsSamplingProbabilitySet;
         }
 
         public void Start()
@@ -69,7 +71,7 @@ namespace BugsnagUnityPerformance
 
         public void Deliver(List<Span> batch)
         {
-            var payload = new TracePayload(_resourceModel, batch);
+            var payload = new TracePayload(_resourceModel, batch, _probabilityOverride);
             MainThreadDispatchBehaviour.Instance().Enqueue(PushToServer(payload, OnTraceDeliveryCompleted));
         }
 
@@ -99,7 +101,7 @@ namespace BugsnagUnityPerformance
             {
                 onResponse = OnPValueRequestCompleted;
             }
-            var payload = new TracePayload(_resourceModel, null);
+            var payload = new TracePayload(_resourceModel, null, false);
             MainThreadDispatchBehaviour.Instance().Enqueue(PushToServer(payload, onResponse));
         }
 

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Delivery.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Delivery.cs
@@ -61,7 +61,7 @@ namespace BugsnagUnityPerformance
         {
             _endpoint = config.Endpoint;
             _apiKey = config.ApiKey;
-            _probabilityOverride = config.IsSamplingProbabilitySet;
+            _probabilityOverride = config.IsSamplingProbabilityOverriden;
         }
 
         public void Start()

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Delivery.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Delivery.cs
@@ -61,7 +61,7 @@ namespace BugsnagUnityPerformance
         {
             _endpoint = config.Endpoint;
             _apiKey = config.ApiKey;
-            _probabilityOverride = config.IsSamplingProbabilityOverriden;
+            _probabilityOverride = config.IsFixedSamplingProbability;
         }
 
         public void Start()

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/PValueUpdater.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/PValueUpdater.cs
@@ -12,6 +12,7 @@ namespace BugsnagUnityPerformance
         private DateTime _pValueTimeout;
         private float _pValueTimeoutSeconds;
         private float _pValueCheckIntervalSeconds;
+        public bool IsConfigured { get; private set; }
 
         public PValueUpdater(Delivery delivery, Sampler sampler)
         {
@@ -24,6 +25,7 @@ namespace BugsnagUnityPerformance
         {
             _pValueTimeoutSeconds = config.PValueTimeoutSeconds;
             _pValueCheckIntervalSeconds = config.PValueCheckIntervalSeconds;
+            IsConfigured = true;
         }
 
         public void Start()

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/PValueUpdater.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/PValueUpdater.cs
@@ -13,6 +13,8 @@ namespace BugsnagUnityPerformance
         private float _pValueTimeoutSeconds;
         private float _pValueCheckIntervalSeconds;
 
+        private bool _probabilityOverride = false;
+
 
         public PValueUpdater(Delivery delivery, Sampler sampler)
         {
@@ -25,10 +27,16 @@ namespace BugsnagUnityPerformance
         {
             _pValueTimeoutSeconds = config.PValueTimeoutSeconds;
             _pValueCheckIntervalSeconds = config.PValueCheckIntervalSeconds;
+            _probabilityOverride = config.IsSamplingProbabilitySet;
         }
 
         public void Start()
         {
+            // If the probability is overridden, we don't need to check for p value updates
+            if(_probabilityOverride)
+            {
+                return;
+            }
             MainThreadDispatchBehaviour.Instance().Enqueue(CheckPValue());
         }
         

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/PValueUpdater.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/PValueUpdater.cs
@@ -27,7 +27,7 @@ namespace BugsnagUnityPerformance
         {
             _pValueTimeoutSeconds = config.PValueTimeoutSeconds;
             _pValueCheckIntervalSeconds = config.PValueCheckIntervalSeconds;
-            _probabilityOverride = config.IsSamplingProbabilitySet;
+            _probabilityOverride = config.IsSamplingProbabilityOverriden;
         }
 
         public void Start()

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/PValueUpdater.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/PValueUpdater.cs
@@ -13,9 +13,6 @@ namespace BugsnagUnityPerformance
         private float _pValueTimeoutSeconds;
         private float _pValueCheckIntervalSeconds;
 
-        private bool _probabilityOverride = false;
-
-
         public PValueUpdater(Delivery delivery, Sampler sampler)
         {
             _delivery = delivery;
@@ -27,16 +24,10 @@ namespace BugsnagUnityPerformance
         {
             _pValueTimeoutSeconds = config.PValueTimeoutSeconds;
             _pValueCheckIntervalSeconds = config.PValueCheckIntervalSeconds;
-            _probabilityOverride = config.IsSamplingProbabilityOverriden;
         }
 
         public void Start()
         {
-            // If the probability is overridden, we don't need to check for p value updates
-            if(_probabilityOverride)
-            {
-                return;
-            }
             MainThreadDispatchBehaviour.Instance().Enqueue(CheckPValue());
         }
         

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Sampler.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Sampler.cs
@@ -5,8 +5,7 @@ namespace BugsnagUnityPerformance
     {
         private PersistentState _persistentState;
 
-        private double _probability = 1;
-        private bool _probabilityOverride = false;
+        private double _probability = -1;
 
         public double Probability
         {
@@ -28,28 +27,27 @@ namespace BugsnagUnityPerformance
 
         public void Configure(PerformanceConfiguration config)
         {
-            _probabilityOverride = config.IsSamplingProbabilityOverriden;
-            _probability = _probabilityOverride ? config.SamplingProbability : 1.0;
+            if (config.IsFixedSamplingProbability)
+            {
+                _probability = config.SamplingProbability;
+            }
         }
 
         public void Start()
         {
-            if(!_probabilityOverride)
+            // If the probability is not set, try to load it from the persistent state, otherwise set it to 1.0
+            if (_probability < 0)
             {
-                GetStoredProbability();
-            }
-        }
-
-        private void GetStoredProbability()
-        {
-            var storedProbability = _persistentState.Probability;
-            if (storedProbability >= 0)
-            {
-                _probability = storedProbability;
-            }
-            else
-            {
-                _persistentState.Probability = _probability;
+                var storedProbability = _persistentState.Probability;
+                if (storedProbability >= 0)
+                {
+                    _probability = storedProbability;
+                }
+                else
+                {
+                    _probability = 1.0;
+                    _persistentState.Probability = _probability;
+                }
             }
         }
 

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Sampler.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Sampler.cs
@@ -5,7 +5,7 @@ namespace BugsnagUnityPerformance
     {
         private PersistentState _persistentState;
 
-        private double _probability = -1;
+        private double _probability = 1;
 
         public double Probability
         {
@@ -27,7 +27,14 @@ namespace BugsnagUnityPerformance
 
         public void Configure(PerformanceConfiguration config)
         {
-            _probability = config.SamplingProbability;
+            if(config.IsSamplingProbabilitySet)
+            {
+                _probability = config.SamplingProbability;
+            }
+            else
+            {
+                _probability = 1.0;
+            }
         }
 
         public void Start()

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Sampler.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Sampler.cs
@@ -6,6 +6,7 @@ namespace BugsnagUnityPerformance
         private PersistentState _persistentState;
 
         private double _probability = 1;
+        private bool _probabilityOverride = false;
 
         public double Probability
         {
@@ -27,17 +28,19 @@ namespace BugsnagUnityPerformance
 
         public void Configure(PerformanceConfiguration config)
         {
-            if(config.IsSamplingProbabilitySet)
-            {
-                _probability = config.SamplingProbability;
-            }
-            else
-            {
-                _probability = 1.0;
-            }
+            _probabilityOverride = config.IsSamplingProbabilityOverriden;
+            _probability = _probabilityOverride ? config.SamplingProbability : 1.0;
         }
 
         public void Start()
+        {
+            if(!_probabilityOverride)
+            {
+                GetStoredProbability();
+            }
+        }
+
+        private void GetStoredProbability()
         {
             var storedProbability = _persistentState.Probability;
             if (storedProbability >= 0)

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/TracePayload.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/TracePayload.cs
@@ -20,7 +20,7 @@ namespace BugsnagUnityPerformance
 
         private string _jsonbody;
 
-        public TracePayload(ResourceModel resourceModel, List<Span> spans)
+        public TracePayload(ResourceModel resourceModel, List<Span> spans, bool probabilityOverride)
         {
             _resourceModel = resourceModel;
             if (spans != null && spans.Count > 0)
@@ -32,11 +32,17 @@ namespace BugsnagUnityPerformance
                     _spans.Add(new SpanModel(span));
                 }
                 SamplingHistogram = CalculateSamplingHistorgram(spans);
-                Headers["Bugsnag-Span-Sampling"] = BuildSamplingHistogramHeader(this);
+                if(!probabilityOverride)
+                {
+                    Headers["Bugsnag-Span-Sampling"] = BuildSamplingHistogramHeader(this);
+                }
             }
             else
             {
-                Headers["Bugsnag-Span-Sampling"] = "1:0";
+                if(!probabilityOverride)
+                {
+                    Headers["Bugsnag-Span-Sampling"] = "1:0";
+                }
             }
         }
 

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/TracePayload.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/TracePayload.cs
@@ -20,7 +20,7 @@ namespace BugsnagUnityPerformance
 
         private string _jsonbody;
 
-        public TracePayload(ResourceModel resourceModel, List<Span> spans, bool probabilityOverride)
+        public TracePayload(ResourceModel resourceModel, List<Span> spans, bool isFixedSamplingProbability)
         {
             _resourceModel = resourceModel;
             if (spans != null && spans.Count > 0)
@@ -32,14 +32,14 @@ namespace BugsnagUnityPerformance
                     _spans.Add(new SpanModel(span));
                 }
                 SamplingHistogram = CalculateSamplingHistorgram(spans);
-                if(!probabilityOverride)
+                if(!isFixedSamplingProbability)
                 {
                     Headers["Bugsnag-Span-Sampling"] = BuildSamplingHistogramHeader(this);
                 }
             }
             else
             {
-                if(!probabilityOverride)
+                if(!isFixedSamplingProbability)
                 {
                     Headers["Bugsnag-Span-Sampling"] = "1:0";
                 }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformance.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformance.cs
@@ -30,6 +30,7 @@ namespace BugsnagUnityPerformance
         private static List<Span> _potentiallyOpenSpans = new List<Span>();
         private Func<BugsnagNetworkRequestInfo, BugsnagNetworkRequestInfo> _networkRequestCallback;
         private static Regex[] _tracePropagationUrlMatchPatterns;
+        private bool _isSamplingProbabilityOverriden;
 
 
         public static void Start(PerformanceConfiguration configuration)
@@ -136,13 +137,17 @@ namespace BugsnagUnityPerformance
 
         private void Configure(PerformanceConfiguration config)
         {
+            _isSamplingProbabilityOverriden = config.IsFixedSamplingProbability;
             _networkRequestCallback = config.NetworkRequestCallback;
             _cacheManager.Configure(config);
             _persistentState.Configure(config);
             _delivery.Configure(config);
             _resourceModel.Configure(config);
             _sampler.Configure(config);
-            _pValueUpdater.Configure(config);
+            if(!_isSamplingProbabilityOverriden)
+            {
+                _pValueUpdater.Configure(config);
+            }
             _tracer.Configure(config);
             _appStartHandler.Configure(config);
         }
@@ -155,7 +160,10 @@ namespace BugsnagUnityPerformance
             _delivery.Start();
             _resourceModel.Start();
             _sampler.Start();
-            _pValueUpdater.Start();
+            if(!_isSamplingProbabilityOverriden)
+            {
+               _pValueUpdater.Start();
+            }
             _tracer.Start();
             _appStartHandler.Start();
             SetupNetworkListener();

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformance.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformance.cs
@@ -30,8 +30,6 @@ namespace BugsnagUnityPerformance
         private static List<Span> _potentiallyOpenSpans = new List<Span>();
         private Func<BugsnagNetworkRequestInfo, BugsnagNetworkRequestInfo> _networkRequestCallback;
         private static Regex[] _tracePropagationUrlMatchPatterns;
-        private bool _isSamplingProbabilityOverriden;
-
 
         public static void Start(PerformanceConfiguration configuration)
         {
@@ -137,14 +135,13 @@ namespace BugsnagUnityPerformance
 
         private void Configure(PerformanceConfiguration config)
         {
-            _isSamplingProbabilityOverriden = config.IsFixedSamplingProbability;
             _networkRequestCallback = config.NetworkRequestCallback;
             _cacheManager.Configure(config);
             _persistentState.Configure(config);
             _delivery.Configure(config);
             _resourceModel.Configure(config);
             _sampler.Configure(config);
-            if(!_isSamplingProbabilityOverriden)
+            if(!config.IsFixedSamplingProbability)
             {
                 _pValueUpdater.Configure(config);
             }
@@ -160,7 +157,7 @@ namespace BugsnagUnityPerformance
             _delivery.Start();
             _resourceModel.Start();
             _sampler.Start();
-            if(!_isSamplingProbabilityOverriden)
+            if(_pValueUpdater.IsConfigured)
             {
                _pValueUpdater.Start();
             }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
@@ -8,6 +8,12 @@ namespace BugsnagUnityPerformance
     public class PerformanceConfiguration
     {
 
+
+        public PerformanceConfiguration(string apiKey)
+        {
+            ApiKey = apiKey;
+        }
+
         //Internal config
 
         internal int MaxBatchSize = 100;
@@ -15,7 +21,6 @@ namespace BugsnagUnityPerformance
         internal int MaxPersistedBatchAgeSeconds = 86400; //24 hours
         internal float PValueTimeoutSeconds = 86400f;
         internal float PValueCheckIntervalSeconds = 30f;
-        internal double SamplingProbability = 1.0;
 
         //Public config
 
@@ -26,7 +31,7 @@ namespace BugsnagUnityPerformance
         public string AppVersion = Application.version;
         public int VersionCode = -1;
         public string BundleVersion;
-      
+
         public bool GenerateAnonymousId = true;
 
         public string[] EnabledReleaseStages;
@@ -53,14 +58,12 @@ namespace BugsnagUnityPerformance
         {
             return _onSpanEndCallbacks;
         }
-        
+
         private List<Func<Span, bool>> _onSpanEndCallbacks = new List<Func<Span, bool>>();
 
-        public PerformanceConfiguration(string apiKey)
-        {
-            ApiKey = apiKey;
-        }
+        public double SamplingProbability = -1.0;
 
-      
+        public bool IsSamplingProbabilitySet => SamplingProbability >= 0;
+
     }
 }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
@@ -65,7 +65,7 @@ namespace BugsnagUnityPerformance
 
         public double SamplingProbability = -1.0;
 
-        internal bool IsSamplingProbabilityOverriden => SamplingProbability >= 0;
+        internal bool IsFixedSamplingProbability => SamplingProbability >= 0;
 
     }
 }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using UnityEngine;
 
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Tests")]
+
 namespace BugsnagUnityPerformance
 {
     public class PerformanceConfiguration

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
@@ -63,7 +63,7 @@ namespace BugsnagUnityPerformance
 
         public double SamplingProbability = -1.0;
 
-        public bool IsSamplingProbabilitySet => SamplingProbability >= 0;
+        internal bool IsSamplingProbabilityOverriden => SamplingProbability >= 0;
 
     }
 }

--- a/BugsnagPerformance/Assets/UnitTests/ConfigurationTests.cs
+++ b/BugsnagPerformance/Assets/UnitTests/ConfigurationTests.cs
@@ -76,9 +76,9 @@ namespace Tests
         public void CustomSamplingValue()
         {
             var config = new PerformanceConfiguration(VALID_API_KEY);
-            Assert.IsFalse(config.IsSamplingProbabilityOverriden);
+            Assert.IsFalse(config.IsFixedSamplingProbability);
             config.SamplingProbability = 0.5;
-            Assert.IsTrue(config.IsSamplingProbabilityOverriden);
+            Assert.IsTrue(config.IsFixedSamplingProbability);
         }
 
     }

--- a/BugsnagPerformance/Assets/UnitTests/ConfigurationTests.cs
+++ b/BugsnagPerformance/Assets/UnitTests/ConfigurationTests.cs
@@ -72,5 +72,14 @@ namespace Tests
             Assert.IsFalse(config.TracePropagationUrls[1].IsMatch(nonMatchingUrl2));
         }
 
+        [Test]
+        public void CustomSamplingValue()
+        {
+            var config = new PerformanceConfiguration(VALID_API_KEY);
+            Assert.IsFalse(config.IsSamplingProbabilityOverriden);
+            config.SamplingProbability = 0.5;
+            Assert.IsTrue(config.IsSamplingProbabilityOverriden);
+        }
+
     }
 }

--- a/BugsnagPerformance/Assets/UnitTests/SamplerTests.cs
+++ b/BugsnagPerformance/Assets/UnitTests/SamplerTests.cs
@@ -98,7 +98,7 @@ namespace Tests
         public void TestProbability0_0()
         {
             var config = new PerformanceConfiguration(VALID_API_KEY);
-            SetSamplingProbability(config, 0.0);
+            config.SamplingProbability = 0.0;
             var sampler = NewSampler(config, true);
 
             var span = new Span("test",
@@ -117,7 +117,7 @@ namespace Tests
         public void TestProbability0_1()
         {
             var config = new PerformanceConfiguration(VALID_API_KEY);
-            SetSamplingProbability(config, 0.1);
+            config.SamplingProbability = 0.1;
             var sampler = NewSampler(config, true);
 
             var span = new Span("test",
@@ -147,7 +147,7 @@ namespace Tests
         public void TestProbability0_9()
         {
             var config = new PerformanceConfiguration(VALID_API_KEY);
-            SetSamplingProbability(config, 0.9);
+            config.SamplingProbability = 0.9;
             var sampler = NewSampler(config, true);
 
             var span = new Span("test",
@@ -183,10 +183,5 @@ namespace Tests
 
         }
 
-        private void SetSamplingProbability(PerformanceConfiguration configuration, double p)
-        {
-            var fieldInfo = typeof(PerformanceConfiguration).GetField("SamplingProbability", BindingFlags.Instance | BindingFlags.NonPublic);
-            fieldInfo.SetValue(configuration, p);
-        }
     }
 }

--- a/BugsnagPerformance/Assets/UnitTests/TracePayloadTests.cs
+++ b/BugsnagPerformance/Assets/UnitTests/TracePayloadTests.cs
@@ -90,7 +90,7 @@ namespace Tests
         {
             var cacheManager = new CacheManager(Application.temporaryCachePath);
             var resourceModel = new ResourceModel(cacheManager);
-            return new TracePayload(resourceModel, SpansWithProbabilities(pValues));
+            return new TracePayload(resourceModel, SpansWithProbabilities(pValues), false);
         }
 
         private void AssertSpanSamplingHistogram(List<double> pValues, string expectedHistogram)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Additions
 
+- Allow setting a fixed Span Sampling probability. [#128](https://github.com/bugsnag/bugsnag-unity-performance/pull/128)
+
 - Allow setting custom span attributes. [#124](https://github.com/bugsnag/bugsnag-unity-performance/pull/124)
 
 ### Bug Fixes

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'cocoapods'
 
 unless Gem.win_platform?
   # Use official Maze Runner release
-  gem 'bugsnag-maze-runner', '~> 9.11.0'
+  gem 'bugsnag-maze-runner', '~> 9.13.0'
 
   # Use a specific Maze Runner branch
   #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'master'

--- a/features/fixtures/mazerunner/Assets/Scenes/MainScene.unity
+++ b/features/fixtures/mazerunner/Assets/Scenes/MainScene.unity
@@ -800,6 +800,8 @@ GameObject:
   - component: {fileID: 805103370}
   - component: {fileID: 805103372}
   - component: {fileID: 805103371}
+  - component: {fileID: 805103374}
+  - component: {fileID: 805103373}
   m_Layer: 0
   m_Name: Sampling
   m_TagString: Untagged
@@ -848,6 +850,30 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ShouldStartNotifier: 0
+--- !u!114 &805103373
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 805103369}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9cb2c8811d6324400807420081864590, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &805103374
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 805103369}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b326621b51b34e96a0c8b53f3e6f3b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &895329258
 GameObject:
   m_ObjectHideFlags: 0
@@ -937,6 +963,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: be1de6f2d6c6e48ec9b3b2403f85c46a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ShouldStartNotifier: 0
 --- !u!1 &1294582013
 GameObject:
   m_ObjectHideFlags: 0

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenario.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenario.cs
@@ -95,10 +95,4 @@ public class Scenario : MonoBehaviour
         fieldInfo.SetValue(Configuration, seconds);
     }
 
-    public void SetSamplingProbability(double p)
-    {
-        var fieldInfo = typeof(PerformanceConfiguration).GetField("SamplingProbability", BindingFlags.Instance | BindingFlags.NonPublic);
-        fieldInfo.SetValue(Configuration, p);
-    }
-
 }

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Sampling.meta
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Sampling.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f8ff9e5e5dab84f3fa316f76da6ab4ea
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Sampling/OverrideSampling0.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Sampling/OverrideSampling0.cs
@@ -1,28 +1,21 @@
-﻿using System.Collections;
 using BugsnagUnityPerformance;
 
-public class ConfiguredSamplingRate0 : Scenario
+public class OverrideSampling0 : Scenario
 {
-
-    private Span _span;
-
     public override void PreparePerformanceConfig(string apiKey, string host)
     {
         base.PreparePerformanceConfig(apiKey, host);
-        SetMaxBatchSize(0);
+        Configuration.SamplingProbability = 0;
+        SetMaxBatchSize(1);
     }
 
     public override void Run()
     {
-       StartCoroutine(DoSpans());
-    }
-
-    private IEnumerator DoSpans(){
-        yield return new UnityEngine.WaitForSeconds(4);
+        base.Run();
         BugsnagPerformance.StartSpan("ManualSpan1").End();
         BugsnagPerformance.StartSpan("ManualSpan2").End();
         BugsnagPerformance.StartSpan("ManualSpan3").End();
         BugsnagPerformance.StartSpan("ManualSpan4").End();
     }
-
 }
+

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Sampling/OverrideSampling0.cs.meta
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Sampling/OverrideSampling0.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8b326621b51b34e96a0c8b53f3e6f3b4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Sampling/OverrideSampling1.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Sampling/OverrideSampling1.cs
@@ -1,28 +1,24 @@
-﻿using System.Collections;
+using System.Collections;
+using System.Collections.Generic;
 using BugsnagUnityPerformance;
+using UnityEngine;
 
-public class ConfiguredSamplingRate0 : Scenario
+public class OverrideSampling1 : Scenario
 {
-
-    private Span _span;
-
     public override void PreparePerformanceConfig(string apiKey, string host)
     {
         base.PreparePerformanceConfig(apiKey, host);
-        SetMaxBatchSize(0);
+        Configuration.SamplingProbability = 1;
+        SetMaxBatchSize(4);
     }
 
     public override void Run()
     {
-       StartCoroutine(DoSpans());
-    }
-
-    private IEnumerator DoSpans(){
-        yield return new UnityEngine.WaitForSeconds(4);
+        base.Run();
         BugsnagPerformance.StartSpan("ManualSpan1").End();
         BugsnagPerformance.StartSpan("ManualSpan2").End();
         BugsnagPerformance.StartSpan("ManualSpan3").End();
         BugsnagPerformance.StartSpan("ManualSpan4").End();
     }
-
 }
+

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Sampling/OverrideSampling1.cs.meta
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Sampling/OverrideSampling1.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9cb2c8811d6324400807420081864590
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Spans/ConfiguredSamplingRate0.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Spans/ConfiguredSamplingRate0.cs
@@ -11,7 +11,7 @@ public class ConfiguredSamplingRate0 : Scenario
     public override void PreparePerformanceConfig(string apiKey, string host)
     {
         base.PreparePerformanceConfig(apiKey, host);
-        SetSamplingProbability(0);
+        Configuration.SamplingProbability = 0;
         SetMaxBatchAgeSeconds(1);
     }
 

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Spans/ConfiguredSamplingRate1.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Spans/ConfiguredSamplingRate1.cs
@@ -8,8 +8,7 @@ public class ConfiguredSamplingRate1 : Scenario
     public override void PreparePerformanceConfig(string apiKey, string host)
     {
         base.PreparePerformanceConfig(apiKey, host);
-        Configuration.SamplingProbability = 1;
-        SetMaxBatchAgeSeconds(1);
+        SetMaxBatchSize(4);
     }
 
     public override void Run()

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Spans/ConfiguredSamplingRate1.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Spans/ConfiguredSamplingRate1.cs
@@ -8,6 +8,7 @@ public class ConfiguredSamplingRate1 : Scenario
     public override void PreparePerformanceConfig(string apiKey, string host)
     {
         base.PreparePerformanceConfig(apiKey, host);
+        Configuration.SamplingProbability = 1;
         SetMaxBatchAgeSeconds(1);
     }
 

--- a/features/sampling.feature
+++ b/features/sampling.feature
@@ -3,6 +3,28 @@ Feature: Sampling spans
   Background:
     Given I clear the Bugsnag cache
 
+  Scenario: Override sampling in config 1
+    Given I set the sampling probability for the next traces to "0"
+    When I run the game in the "OverrideSampling1" state
+    And I wait for 4 spans
+    Then the trace Bugsnag-Integrity header is valid
+    And the trace "Bugsnag-Api-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+    And the trace "Bugsnag-Span-Sampling" header is not present
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * a span name equals "ManualSpan1"
+    * a span name equals "ManualSpan2"
+    * a span name equals "ManualSpan3"
+    * a span name equals "ManualSpan4"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"    
+
+  Scenario: Override sampling in config 0
+    Given I set the sampling probability for the next traces to "1"
+    When I run the game in the "OverrideSampling0" state
+    Then I should receive no traces
+
   Scenario: With probability 1, all spans are sampled
     Given I set the sampling probability for the next traces to "1"
     When I run the game in the "ConfiguredSamplingRate1" state

--- a/features/sampling.feature
+++ b/features/sampling.feature
@@ -5,6 +5,7 @@ Feature: Sampling spans
 
   Scenario: Override sampling in config 1
     Given I set the sampling probability for the next traces to "0"
+    And I enter unmanaged traces mode
     When I run the game in the "OverrideSampling1" state
     And I wait for 4 spans
     Then the trace Bugsnag-Integrity header is valid

--- a/features/sampling.feature
+++ b/features/sampling.feature
@@ -3,7 +3,7 @@ Feature: Sampling spans
   Background:
     Given I clear the Bugsnag cache
 
-  Scenario: Override sampling in config 1
+  Scenario: Setting fixed sampling probability of 1 with dynamic probability of 0 should send all spans
     Given I set the sampling probability for the next traces to "0"
     And I enter unmanaged traces mode
     When I run the game in the "OverrideSampling1" state
@@ -21,12 +21,12 @@ Feature: Sampling spans
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"    
 
-  Scenario: Override sampling in config 0
+  Scenario: Setting fixed sampling probability of 0 with dynamic probability of 1 should send no spans
     Given I set the sampling probability for the next traces to "1"
     When I run the game in the "OverrideSampling0" state
     Then I should receive no traces
 
-  Scenario: With probability 1, all spans are sampled
+  Scenario: With dynamic probability of 1 and no fixed probability, all spans are sampled
     Given I set the sampling probability for the next traces to "1"
     When I run the game in the "ConfiguredSamplingRate1" state
     And I wait for 4 spans
@@ -43,7 +43,7 @@ Feature: Sampling spans
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"    
 
-  Scenario: With probability 0, no spans are sampled
+  Scenario: With dynamic probability of 0 and no fixed probability, no spans are sampled
     Given I set the sampling probability for the next traces to "0"
     When I run the game in the "ConfiguredSamplingRate0" state
     Then I should receive no traces


### PR DESCRIPTION
## Goal

Expose `SamplingProbability`, unset by default, causing the SDK to use the current dynamic sampling logic

If set:
- disable the initial and periodic p-value requests being sent
- disable the setting of the Bugsnag-Span-Sampling header
- keep the bugsnag.sampling.p attribute for possible future use

## Testing

Updated unit tests and E2E tests
