### PR TITLE
PLAT-12447 use API key subdomain as endpoint

### DIFF
--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Delivery.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Delivery.cs
@@ -57,7 +57,6 @@ namespace BugsnagUnityPerformance
 
         public void Configure(PerformanceConfiguration config)
         {
-            Debug.Log("Set endpoint to " + config.GetEndpoint());
             _endpoint = config.GetEndpoint();
             _apiKey = config.ApiKey;
             _isFixedSamplingProbability = config.IsFixedSamplingProbability;

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Delivery.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Delivery.cs
@@ -57,7 +57,8 @@ namespace BugsnagUnityPerformance
 
         public void Configure(PerformanceConfiguration config)
         {
-            _endpoint = config.Endpoint;
+            Debug.Log("Set endpoint to " + config.GetEndpoint());
+            _endpoint = config.GetEndpoint();
             _apiKey = config.ApiKey;
             _isFixedSamplingProbability = config.IsFixedSamplingProbability;
         }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformanceSettingsObject.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformanceSettingsObject.cs
@@ -18,7 +18,7 @@ namespace BugsnagUnityPerformance
 
         public string[] EnabledReleaseStages;
 
-        public string Endpoint = "https://otlp.bugsnag.com/v1/traces";
+        public string Endpoint = string.Empty;
 
         public string ReleaseStage;
 

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
@@ -10,6 +10,8 @@ namespace BugsnagUnityPerformance
     public class PerformanceConfiguration
     {
 
+        private const string LEGACY_DEFAULT_ENDPOINT = "https://otlp.bugsnag.com/v1/traces";
+        private const string DEFAULT_ENDPOINT = "https://{0}.otlp.bugsnag.com/v1/traces";
 
         public PerformanceConfiguration(string apiKey)
         {
@@ -38,7 +40,8 @@ namespace BugsnagUnityPerformance
 
         public string[] EnabledReleaseStages;
 
-        public string Endpoint = "https://otlp.bugsnag.com/v1/traces";
+        public string Endpoint = string.Empty;
+
 
         public Func<BugsnagNetworkRequestInfo, BugsnagNetworkRequestInfo> NetworkRequestCallback;
 
@@ -66,6 +69,15 @@ namespace BugsnagUnityPerformance
         public double SamplingProbability = -1.0;
 
         internal bool IsFixedSamplingProbability => SamplingProbability >= 0;
+
+        public string GetEndpoint()
+        {
+            if(string.IsNullOrEmpty(Endpoint) || Endpoint == LEGACY_DEFAULT_ENDPOINT)
+            {
+                return string.Format(DEFAULT_ENDPOINT,ApiKey);
+            }
+            return Endpoint;
+        }
 
     }
 }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
@@ -74,7 +74,7 @@ namespace BugsnagUnityPerformance
         {
             if(string.IsNullOrEmpty(Endpoint) || Endpoint == LEGACY_DEFAULT_ENDPOINT)
             {
-                return string.Format(DEFAULT_ENDPOINT,ApiKey);
+                return string.Format(DEFAULT_ENDPOINT, ApiKey);
             }
             return Endpoint;
         }

--- a/BugsnagPerformance/Assets/UnitTests/ConfigurationTests.cs
+++ b/BugsnagPerformance/Assets/UnitTests/ConfigurationTests.cs
@@ -16,10 +16,50 @@ namespace Tests
 
         private DateTimeOffset CustomStartTime = new DateTimeOffset(1985, 1, 1, 1, 1, 1, System.TimeSpan.Zero);
         private DateTimeOffset CustomEndTime = new DateTimeOffset(1986, 1, 1, 1, 1, 1, System.TimeSpan.Zero);
+        private const string LEGACY_DEFAULT_ENDPOINT = "https://otlp.bugsnag.com/v1/traces";
+        private const string DEFAULT_ENDPOINT_FORMAT = "https://{0}.otlp.bugsnag.com/v1/traces";
 
         private void OnSpanEnd(Span span)
         {
             // Nothing to do
+        }
+
+        [Test]
+        public void TestEndpointWhenUnset()
+        {
+            var config = new PerformanceConfiguration(VALID_API_KEY);
+            var endpoint = config.GetEndpoint();
+            var expectedEndpoint = string.Format(DEFAULT_ENDPOINT_FORMAT, VALID_API_KEY);
+            Assert.AreEqual(expectedEndpoint, endpoint);
+        }
+
+        [Test]
+        public void TestEndpointWhenSetToLegacyDefault()
+        {
+            var config = new PerformanceConfiguration(VALID_API_KEY);
+            config.Endpoint = LEGACY_DEFAULT_ENDPOINT;
+            var endpoint = config.GetEndpoint();
+            var expectedEndpoint = string.Format(DEFAULT_ENDPOINT_FORMAT, VALID_API_KEY);
+            Assert.AreEqual(expectedEndpoint, endpoint);
+        }
+
+        [Test]
+        public void TestEndpointWhenSetToCustomValue()
+        {
+            var config = new PerformanceConfiguration(VALID_API_KEY);
+            string customEndpoint = "https://custom.endpoint.com/traces";
+            config.Endpoint = customEndpoint;
+            var endpoint = config.GetEndpoint();
+            Assert.AreEqual(customEndpoint, endpoint);
+        }
+
+        [Test]
+        public void TestEndpointWithNullApiKey()
+        {
+            var config = new PerformanceConfiguration(null);
+            var endpoint = config.GetEndpoint();
+            var expectedEndpoint = string.Format(DEFAULT_ENDPOINT_FORMAT, string.Empty);
+            Assert.AreEqual(expectedEndpoint, endpoint);
         }
 
         [Test]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Allow setting custom span attributes. [#124](https://github.com/bugsnag/bugsnag-unity-performance/pull/124)
 - Changed internal Span references to WeakReferences to avoid memory leaks. [#127](https://github.com/bugsnag/bugsnag-unity-performance/pull/127)
 
+- Use API key subdomain as default Performance endpoint. [#129](https://github.com/bugsnag/bugsnag-unity-performance/pull/129)
+
 ### Bug Fixes
 
 - Fix an issue where TracePropagationUrls was incorrectly named and typed. [#126](https://github.com/bugsnag/bugsnag-unity-performance/pull/126)


### PR DESCRIPTION
## Goal

use API key subdomain as endpoint

### Note

The original default endpoint must be checked against because if someone was using the bugsnag config window and the default endpoint and then updates to the new release, then it will be read from the config file anyway and override the new default.

## Testing

Added unit tests