### PR TITLE
PLAT-12051 add service.name attribute

### DIFF
--- a/BugsnagPerformance/Assets/BugsnagPerformance/Editor/BugsnagPerformanceEditor.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Editor/BugsnagPerformanceEditor.cs
@@ -87,11 +87,11 @@ public class BugsnagPerformanceEditor : EditorWindow
             EditorGUIUtility.labelWidth = 280;
             settings.UseNotifierSettings = EditorGUILayout.Toggle("Use BugSnag Error Monitoring SDK Settings", settings.UseNotifierSettings);
         }
-     
+
 
         if (!NotifierConfigAvaliable() || !settings.UseNotifierSettings)
         {
-            DrawStandaloneSettings(so,settings);
+            DrawStandaloneSettings(so, settings);
         }
 
         if (NotifierConfigAvaliable() && settings.UseNotifierSettings)
@@ -100,12 +100,12 @@ public class BugsnagPerformanceEditor : EditorWindow
         }
 
         EditorGUIUtility.labelWidth = 200;
-        EditorGUILayout.PropertyField(so.FindProperty("AutoInstrumentAppStart"));
         EditorGUILayout.PropertyField(so.FindProperty("Endpoint"));
 
+        EditorGUILayout.PropertyField(so.FindProperty("AutoInstrumentAppStart"));
+        EditorGUILayout.PropertyField(so.FindProperty("ServiceName"));
+
         EditorGUI.indentLevel--;
-
-
         so.ApplyModifiedProperties();
         EditorUtility.SetDirty(settings);
     }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Models/ResourceModel.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Models/ResourceModel.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace BugsnagUnityPerformance
 {
-    public class ResourceModel: IPhasedStartup
+    public class ResourceModel : IPhasedStartup
     {
         private CacheManager _cacheManager;
 
@@ -24,9 +24,9 @@ namespace BugsnagUnityPerformance
                 new AttributeModel("telemetry.sdk.version", Version.VersionString),
                 new AttributeModel("device.model.identifier", SystemInfo.deviceModel),
                 new AttributeModel("service.version", string.IsNullOrEmpty(config.AppVersion) ? Application.version : config.AppVersion),
+                new AttributeModel("service.name", GetServiceName(config)),
                 new AttributeModel("bugsnag.app.platform", GetPlatform()),
-                new AttributeModel("bugsnag.runtime_versions.unity", Application.unityVersion),
-                new AttributeModel("service.name", string.IsNullOrEmpty(config.ServiceName) ? Application.identifier : config.ServiceName)
+                new AttributeModel("bugsnag.runtime_versions.unity", Application.unityVersion)
             };
             AddNonNullAttribute(GetNativeVersionInfo(config));
             AddNonNullAttribute(GetManufacturer());
@@ -46,6 +46,18 @@ namespace BugsnagUnityPerformance
         public void Start()
         {
             attributes.Add(new AttributeModel("device.id", _cacheManager.GetDeviceId()));
+        }
+
+        private string GetServiceName(PerformanceConfiguration config)
+        {
+            if (!string.IsNullOrEmpty(config.ServiceName))
+            {
+                return config.ServiceName;
+            }
+
+            var name = Application.identifier ?? Application.productName;
+
+            return !string.IsNullOrEmpty(name) ? name : "unknown_service";
         }
 
         private string GetPlatform()
@@ -85,7 +97,7 @@ namespace BugsnagUnityPerformance
         {
             if (!string.IsNullOrEmpty(config.BundleVersion))
             {
-                return new AttributeModel("bugsnag.app.bundle_version",  config.BundleVersion);
+                return new AttributeModel("bugsnag.app.bundle_version", config.BundleVersion);
             }
             return new AttributeModel("bugsnag.app.bundle_version", Application.platform == RuntimePlatform.IPhonePlayer ? iOSNative.GetBundleVersion() : MacOSNative.GetBundleVersion());
         }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Models/ResourceModel.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Models/ResourceModel.cs
@@ -25,8 +25,8 @@ namespace BugsnagUnityPerformance
                 new AttributeModel("device.model.identifier", SystemInfo.deviceModel),
                 new AttributeModel("service.version", string.IsNullOrEmpty(config.AppVersion) ? Application.version : config.AppVersion),
                 new AttributeModel("bugsnag.app.platform", GetPlatform()),
-                new AttributeModel("bugsnag.runtime_versions.unity", Application.unityVersion)
-               
+                new AttributeModel("bugsnag.runtime_versions.unity", Application.unityVersion),
+                new AttributeModel("service.name", string.IsNullOrEmpty(config.ServiceName) ? Application.identifier : config.ServiceName)
             };
             AddNonNullAttribute(GetNativeVersionInfo(config));
             AddNonNullAttribute(GetManufacturer());

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Models/ResourceModel.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Models/ResourceModel.cs
@@ -55,9 +55,12 @@ namespace BugsnagUnityPerformance
                 return config.ServiceName;
             }
 
-            var name = Application.identifier ?? Application.productName;
-
-            return !string.IsNullOrEmpty(name) ? name : "unknown_service";
+            var name = string.IsNullOrEmpty(Application.identifier) ? Application.productName : Application.identifier;
+            if (string.IsNullOrEmpty(name))
+            {
+                return "unknown_service";
+            }
+            return name;
         }
 
         private string GetPlatform()

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformanceSettingsObject.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformanceSettingsObject.cs
@@ -25,6 +25,7 @@ namespace BugsnagUnityPerformance
         public string AppVersion;
         public int VersionCode = -1;
         public string BundleVersion;
+        public string ServiceName;
 
         public bool GenerateAnonymousId = true;
 
@@ -60,7 +61,9 @@ namespace BugsnagUnityPerformance
             config.Endpoint = Endpoint;
 
             config.GenerateAnonymousId = GenerateAnonymousId;
-            
+
+            config.ServiceName = ServiceName;
+
             return config;
         }
 

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
@@ -70,6 +70,8 @@ namespace BugsnagUnityPerformance
 
         internal bool IsFixedSamplingProbability => SamplingProbability >= 0;
 
+        public string ServiceName = string.Empty;
+
         public string GetEndpoint()
         {
             if(string.IsNullOrEmpty(Endpoint) || Endpoint == LEGACY_DEFAULT_ENDPOINT)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - Use API key subdomain as default Performance endpoint. [#129](https://github.com/bugsnag/bugsnag-unity-performance/pull/129)
 
-- Added the serivce name resource attribute. [#130] (https://github.com/bugsnag/bugsnag-unity-performance/pull/130)
+- Added the service name resource attribute. [#130] (https://github.com/bugsnag/bugsnag-unity-performance/pull/130)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@
 - Allow setting a fixed Span Sampling probability. [#128](https://github.com/bugsnag/bugsnag-unity-performance/pull/128)
 
 - Allow setting custom span attributes. [#124](https://github.com/bugsnag/bugsnag-unity-performance/pull/124)
+
 - Changed internal Span references to WeakReferences to avoid memory leaks. [#127](https://github.com/bugsnag/bugsnag-unity-performance/pull/127)
 
 - Use API key subdomain as default Performance endpoint. [#129](https://github.com/bugsnag/bugsnag-unity-performance/pull/129)
+
+- Added the serivce name resource attribute. [#130] (https://github.com/bugsnag/bugsnag-unity-performance/pull/130)
 
 ### Bug Fixes
 

--- a/features/configuration.feature
+++ b/features/configuration.feature
@@ -58,3 +58,10 @@ Feature: Configuration tests
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "VersionCode"
     * the trace payload field "resourceSpans.0.resource" string attribute "bugsnag.app.version_code" equals "123"
     * the trace payload field "resourceSpans.0.resource" string attribute "bugsnag.device.android_api_version" exists
+
+  Scenario: Custom Service Name
+    When I run the game in the "CustomServiceName" state
+    And I wait for 1 span
+    Then the trace Bugsnag-Integrity header is valid
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "CustomServiceName"
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "custom.service.name"

--- a/features/fixtures/mazerunner/Assets/Scenes/MainScene.unity
+++ b/features/fixtures/mazerunner/Assets/Scenes/MainScene.unity
@@ -862,6 +862,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9cb2c8811d6324400807420081864590, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ShouldStartNotifier: 0
 --- !u!114 &805103374
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -874,6 +875,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b326621b51b34e96a0c8b53f3e6f3b4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ShouldStartNotifier: 0
 --- !u!1 &895329258
 GameObject:
   m_ObjectHideFlags: 0
@@ -1024,6 +1026,7 @@ GameObject:
   - component: {fileID: 1452957874}
   - component: {fileID: 1452957873}
   - component: {fileID: 1452957872}
+  - component: {fileID: 1452957875}
   m_Layer: 0
   m_Name: Configuration
   m_TagString: Untagged
@@ -1150,6 +1153,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ShouldStartNotifier: 0
+--- !u!114 &1452957875
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1452957865}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 60784bd8dd5b64233afa1f365ad01f71, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1513513349
 GameObject:
   m_ObjectHideFlags: 0

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Configuration/CustomServiceName.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Configuration/CustomServiceName.cs
@@ -1,0 +1,21 @@
+using System.Collections;
+using System.Collections.Generic;
+using BugsnagUnityPerformance;
+using UnityEngine;
+
+public class CustomServiceName : Scenario
+{
+    public override void PreparePerformanceConfig(string apiKey, string host)
+    {
+        base.PreparePerformanceConfig(apiKey, host);
+        SetMaxBatchSize(1);
+        Configuration.ServiceName = "custom.service.name";
+    }
+
+    public override void Run()
+    {
+        var span = BugsnagPerformance.StartSpan("CustomServiceName");
+        span.End();
+    }
+
+}

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Configuration/CustomServiceName.cs.meta
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Configuration/CustomServiceName.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 60784bd8dd5b64233afa1f365ad01f71
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -29,7 +29,7 @@ Feature: Manual creation of spans
     * the trace payload field "resourceSpans.0.resource" string attribute "device.id" exists
     * the trace payload field "resourceSpans.0.resource" string attribute "device.model.identifier" exists
     * the trace payload field "resourceSpans.0.resource" string attribute "service.version" equals "1.0"
-    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals is one of:
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" is one of:
       | com.bugsnag.fixtures.unity.performance.android |
       | com.bugsnag.fixtures.unity.performance.ios |
       | mazerunner |

--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -32,6 +32,7 @@ Feature: Manual creation of spans
     * the trace payload field "resourceSpans.0.resource" string attribute "service.name" is one of:
       | com.bugsnag.fixtures.unity.performance.android |
       | com.bugsnag.fixtures.unity.performance.ios |
+      | com.bugsnag.mazerunner |
       | mazerunner |
       | unknown_service |
     * the trace payload field "resourceSpans.0.resource" string attribute "bugsnag.app.platform" is one of:

--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -29,8 +29,10 @@ Feature: Manual creation of spans
     * the trace payload field "resourceSpans.0.resource" string attribute "device.id" exists
     * the trace payload field "resourceSpans.0.resource" string attribute "device.model.identifier" exists
     * the trace payload field "resourceSpans.0.resource" string attribute "service.version" equals "1.0"
-    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.mazerunner"
-
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals is one of:
+      | com.bugsnag.fixtures.unity.performance.android |
+      | com.bugsnag.fixtures.unity.performance.ios |
+      | mazerunner |
     * the trace payload field "resourceSpans.0.resource" string attribute "bugsnag.app.platform" is one of:
       | Android |
       | iOS |

--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -29,6 +29,8 @@ Feature: Manual creation of spans
     * the trace payload field "resourceSpans.0.resource" string attribute "device.id" exists
     * the trace payload field "resourceSpans.0.resource" string attribute "device.model.identifier" exists
     * the trace payload field "resourceSpans.0.resource" string attribute "service.version" equals "1.0"
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.mazerunner"
+
     * the trace payload field "resourceSpans.0.resource" string attribute "bugsnag.app.platform" is one of:
       | Android |
       | iOS |

--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -33,6 +33,7 @@ Feature: Manual creation of spans
       | com.bugsnag.fixtures.unity.performance.android |
       | com.bugsnag.fixtures.unity.performance.ios |
       | mazerunner |
+      | unknown_service |
     * the trace payload field "resourceSpans.0.resource" string attribute "bugsnag.app.platform" is one of:
       | Android |
       | iOS |


### PR DESCRIPTION
## Goal

send the app identifier (e.g. com.mycorp.myapp) in the service.name attribute.

## Changeset

- If the config value is not set then we use the [application identifier](https://docs.unity3d.com/ScriptReference/Application-identifier.html). If that is empty then we use [product name](https://docs.unity3d.com/ScriptReference/Application-productName.html). If that is also empty then we report `unknown_service `. 

## Testing

Added E2E tests for custom and default service names