### PR TITLE
PLAT-12684 make finished span queue thread safe

### DIFF
--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Tracer.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Tracer.cs
@@ -186,11 +186,11 @@ namespace BugsnagUnityPerformance
                 new Thread(() =>
                 {
                     List<Span> batch = new List<Span>();
-                    foreach (var finishedSpan in _finishedSpanQueue)
+                    lock (_queueLock)
                     {
-                        batch.Add(finishedSpan);
+                        batch.AddRange(_finishedSpanQueue);
+                        _finishedSpanQueue.Clear();
                     }
-                    _finishedSpanQueue.Clear();
                     if (batch.Count == 0)
                     {
                         return;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Bug Fixes
+
+- Fix an issue where the access to the finished span queue in the tracer was not thread safe. [#132](https://github.com/bugsnag/bugsnag-unity-performance/pull/132)
+
 ## v1.5.0 (2024-09-03)
 
 ### Additions


### PR DESCRIPTION
## Goal

When building a batch, the access to the finished span queue in the tracer class is not thread safe.

## Testing

Manually stress tested as mazerunner cannot handle so many traces at once.