### PR TITLE
Release v1.5.1

### DIFF
--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Tracer.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Tracer.cs
@@ -186,11 +186,11 @@ namespace BugsnagUnityPerformance
                 new Thread(() =>
                 {
                     List<Span> batch = new List<Span>();
-                    foreach (var finishedSpan in _finishedSpanQueue)
+                    lock (_queueLock)
                     {
-                        batch.Add(finishedSpan);
+                        batch.AddRange(_finishedSpanQueue);
+                        _finishedSpanQueue.Clear();
                     }
-                    _finishedSpanQueue.Clear();
                     if (batch.Count == 0)
                     {
                         return;

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Version.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Version.cs
@@ -3,6 +3,6 @@
     internal static class Version
     {
         //TODO set this using sed or something in the release automation task
-        public const string VersionString = "1.5.0";
+        public const string VersionString = "1.5.1";
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Bug Fixes
+
+- Fix an issue where the access to the finished span queue in the tracer was not thread safe. [#132](https://github.com/bugsnag/bugsnag-unity-performance/pull/132)
+
 ## v1.5.0 (2024-09-03)
 
 ### Additions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## TBD
+## v1.5.1 (2024-09-09)
 
 ### Bug Fixes
 


### PR DESCRIPTION
## v1.5.1 (2024-09-09)

### Bug Fixes

- Fix an issue where the access to the finished span queue in the tracer was not thread safe. [#132](https://github.com/bugsnag/bugsnag-unity-performance/pull/132)
