### PR TITLE
Use the latest v9 Maze Runner

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'cocoapods'
 
 unless Gem.win_platform?
   # Use official Maze Runner release
-  gem 'bugsnag-maze-runner', '~> 9.13.0'
+  gem 'bugsnag-maze-runner', '~> 9.0'
 
   # Use a specific Maze Runner branch
   #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'master'


### PR DESCRIPTION
## Goal

Use the latest v9 Maze Runner (when running locally).

## Design

This change means you get the latest v9.something, not just v9.13.something.

## Testing

Basic test performed locally by running `bundle install`.