### PR TITLE
fix flaky webgl sampling test

### DIFF
--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Spans/ConfiguredSamplingRate1.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Spans/ConfiguredSamplingRate1.cs
@@ -14,6 +14,12 @@ public class ConfiguredSamplingRate1 : Scenario
     public override void Run()
     {
         base.Run();
+        StartCoroutine(DoSpans());
+    }
+
+    private IEnumerator DoSpans()
+    {
+        yield return new WaitForSeconds(4);
         BugsnagPerformance.StartSpan("ManualSpan1").End();
         BugsnagPerformance.StartSpan("ManualSpan2").End();
         BugsnagPerformance.StartSpan("ManualSpan3").End();


### PR DESCRIPTION
## Goal

Fix flaky test where the spans were ending before the initial sampling request was finished
