### PR TITLE
add TracePropagationUrls to the configuration window

### DIFF
--- a/BugsnagPerformance/Assets/BugsnagPerformance/Editor/BugsnagPerformanceEditor.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Editor/BugsnagPerformanceEditor.cs
@@ -101,10 +101,9 @@ public class BugsnagPerformanceEditor : EditorWindow
 
         EditorGUIUtility.labelWidth = 200;
         EditorGUILayout.PropertyField(so.FindProperty("Endpoint"));
-
         EditorGUILayout.PropertyField(so.FindProperty("AutoInstrumentAppStart"));
         EditorGUILayout.PropertyField(so.FindProperty("ServiceName"));
-
+        EditorGUILayout.PropertyField(so.FindProperty("TracePropagationUrls"));
         EditorGUI.indentLevel--;
         so.ApplyModifiedProperties();
         EditorUtility.SetDirty(settings);

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformanceSettingsObject.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformanceSettingsObject.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Text.RegularExpressions;
 using UnityEngine;
 
 namespace BugsnagUnityPerformance
@@ -26,6 +27,7 @@ namespace BugsnagUnityPerformance
         public int VersionCode = -1;
         public string BundleVersion;
         public string ServiceName;
+        public string[] TracePropagationUrls;
 
         public bool GenerateAnonymousId = true;
 
@@ -45,8 +47,7 @@ namespace BugsnagUnityPerformance
 
         internal PerformanceConfiguration GetConfig()
         {
-            PerformanceConfiguration config = null;
-
+            PerformanceConfiguration config;
             if (UseNotifierSettings && NotifierConfigAvaliable())
             {
                 config = GetSettingsFromNotifier(out StartAutomaticallyAtLaunch);
@@ -56,15 +57,43 @@ namespace BugsnagUnityPerformance
                 config = GetStandaloneConfig();
             }
 
-            config.AutoInstrumentAppStart = AutoInstrumentAppStart;
-
-            config.Endpoint = Endpoint;
-
-            config.GenerateAnonymousId = GenerateAnonymousId;
-
-            config.ServiceName = ServiceName;
+            GetCommonConfigValues(config);
 
             return config;
+        }
+
+        private void GetCommonConfigValues(PerformanceConfiguration config)
+        {
+            config.AutoInstrumentAppStart = AutoInstrumentAppStart;
+            config.Endpoint = Endpoint;
+            if(TracePropagationUrls != null && TracePropagationUrls.Length > 0)
+            {
+                config.TracePropagationUrls = ConvertTracePropagationUrls(TracePropagationUrls);
+            }
+            config.ServiceName = ServiceName;
+        }
+
+        private Regex[] ConvertTracePropagationUrls(string[] urls)
+        {
+            if (urls == null)
+            {
+                return null;
+            }
+
+            var regexes = new Regex[urls.Length];
+            for (int i = 0; i < urls.Length; i++)
+            {
+                try
+                {
+                    regexes[i] = new Regex(urls[i]);
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError("Error parsing TracePropagationUrl " + urls[i] + " in settings object: " + e.Message);
+                }
+            }
+
+            return regexes;
         }
 
         private PerformanceConfiguration GetStandaloneConfig()

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformanceSettingsObject.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformanceSettingsObject.cs
@@ -89,7 +89,7 @@ namespace BugsnagUnityPerformance
                 }
                 catch (Exception e)
                 {
-                    Debug.LogError("Error parsing TracePropagationUrl " + urls[i] + " in settings object: " + e.Message);
+                    Debug.LogWarning("Error converting TracePropagationUrl " + urls[i] + " into a regex pattern in settings object: " + e.Message);
                 }
             }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Additions
+
+- Add TracePropagationUrls to the configuration window. [#136](https://github.com/bugsnag/bugsnag-unity-performance/pull/136)
+
 ## v1.5.1 (2024-09-09)
 
 ### Bug Fixes


### PR DESCRIPTION
## Goal

Add `TracePropagationUrls` to the configuration window.

## Design

- TracePropagationUrls is presented as a string[] in the window.
- On start the strings are converted. 
- If a conversion fails then we skip the offending string and log a warning message.

## Testing

Manually tested