### PR TITLE
rename and move dropped attribute count to correct place

### DIFF
--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Models/SpanModel.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Models/SpanModel.cs
@@ -14,6 +14,7 @@ namespace BugsnagUnityPerformance
         public string startTimeUnixNano;
         public string endTimeUnixNano;
         public string parentSpanId;
+        public int droppedAttributesCount;
         public List<AttributeModel> attributes = new List<AttributeModel>();
 
         public SpanModel(Span span, int attributeArrayLengthLimit, int attributeStringValueLimit)
@@ -81,11 +82,7 @@ namespace BugsnagUnityPerformance
                     attributes.Add(new AttributeModel(attr.Key, new AttributeDoubleValueModel(doubleValue)));
                 }
             }
-
-            if (span.DroppedAttributesCount > 0)
-            {
-                attributes.Add(new AttributeModel("dropped_attributes_count", new AttributeIntValueModel(span.DroppedAttributesCount)));
-            }
+            droppedAttributesCount = span.DroppedAttributesCount;
         }
 
         private T[] TruncateArrayIfNeeded<T>(T[] array, int limit, string key, string spanName)

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Models/SpanModel.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Models/SpanModel.cs
@@ -111,6 +111,12 @@ namespace BugsnagUnityPerformance
             var duration = time - _unixStart;
             return (duration.Ticks * 100).ToString();
         }
+
+         // This method tells Json.NET whether to serialize the droppedAttributesCount or not.
+        public bool ShouldSerializedroppedAttributesCount()
+        {
+            return droppedAttributesCount > 0;
+        }
     }
 
 }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Models/SpanModel.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Models/SpanModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System;
+using UnityEngine.Scripting;
 
 namespace BugsnagUnityPerformance
 {
@@ -112,7 +113,8 @@ namespace BugsnagUnityPerformance
             return (duration.Ticks * 100).ToString();
         }
 
-         // This method tells Json.NET whether to serialize the droppedAttributesCount or not.
+        // This method tells Json.NET whether to serialize the droppedAttributesCount or not.
+        [Preserve]
         public bool ShouldSerializedroppedAttributesCount()
         {
             return droppedAttributesCount > 0;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Bug Fixes
+
+- Fix an issue where Span.droppedAttributeCount was incorrectly implemented. [#140](https://github.com/bugsnag/bugsnag-unity-performance/pull/140)
+
 ## v1.6.0 (2024-09-24)
 
 ### Additions

--- a/features/custom_attributes.feature
+++ b/features/custom_attributes.feature
@@ -58,7 +58,7 @@ Feature: Custom Attributes
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.5.value.arrayValue.values.0.stringValue" equals "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa*** 1 CHARS TRUNCATED"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "int1" equals 999
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.droppedAttributesCount" equals 77
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes" is an array with 132 elements
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes" is an array with 131 elements
 
 
   Scenario: Custom AttributeLimits
@@ -76,7 +76,7 @@ Feature: Custom Attributes
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.5.value.arrayValue.values.0.stringValue" equals "aaaaaaaaaa*** 1015 CHARS TRUNCATED"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "int1" equals 999
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.droppedAttributesCount" equals 197
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes" is an array with 12 elements
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes" is an array with 11 elements
 
 
 

--- a/features/custom_attributes.feature
+++ b/features/custom_attributes.feature
@@ -57,7 +57,7 @@ Feature: Custom Attributes
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.5.value.arrayValue.values" is an array with 1000 elements
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.5.value.arrayValue.values.0.stringValue" equals "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa*** 1 CHARS TRUNCATED"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "int1" equals 999
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "dropped_attributes_count" equals 77
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.droppedAttributesCount" equals 77
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes" is an array with 132 elements
 
 
@@ -75,7 +75,7 @@ Feature: Custom Attributes
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.5.value.arrayValue.values" is an array with 2 elements
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.5.value.arrayValue.values.0.stringValue" equals "aaaaaaaaaa*** 1015 CHARS TRUNCATED"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "int1" equals 999
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "dropped_attributes_count" equals 197
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.droppedAttributesCount" equals 197
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes" is an array with 12 elements
 
 

--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -18,7 +18,7 @@ Feature: Manual creation of spans
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "net.host.connection.type" equals "wifi"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "custom"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.droppedAttributesCount" equals 0
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.droppedAttributesCount" is null
 
     #Resource attributes
     * the trace payload field "resourceSpans.0.resource" string attribute "deployment.environment" is one of:

--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -18,6 +18,7 @@ Feature: Manual creation of spans
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.endTimeUnixNano" matches the regex "^[0-9]+$"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "net.host.connection.type" equals "wifi"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "custom"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.droppedAttributesCount" equals 0
 
     #Resource attributes
     * the trace payload field "resourceSpans.0.resource" string attribute "deployment.environment" is one of:


### PR DESCRIPTION
## Goal

dropped attribute count was incorrectly implemented, it is now a top level property of a span and named with cammel case.

## Testing

Updated e2e tests