### PR TITLE
change pvalue update to use DateTimeOffset.UtcNow

### DIFF
--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/PValueUpdater.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/PValueUpdater.cs
@@ -10,14 +10,14 @@ namespace BugsnagUnityPerformance
         private PerformanceConfiguration _config;
         private Delivery _delivery;
         private Sampler _sampler;
-        private DateTime _pValueTimeout;
+        private DateTimeOffset _pValueTimeout;
         public bool IsConfigured { get; private set; }
 
         public PValueUpdater(Delivery delivery, Sampler sampler)
         {
             _delivery = delivery;
             _sampler = sampler;
-            _pValueTimeout = DateTime.Now;
+            _pValueTimeout = DateTimeOffset.UtcNow;
         }
 
         public void Configure(PerformanceConfiguration config)
@@ -38,7 +38,7 @@ namespace BugsnagUnityPerformance
 #endif
             while (true)
             {
-                if (DateTime.Now.CompareTo(_pValueTimeout) >= 0)
+                if (DateTimeOffset.UtcNow.CompareTo(_pValueTimeout) >= 0)
                 {
                     _delivery.DeliverPValueRequest(OnPValueRequestCompleted);
                 }
@@ -49,7 +49,7 @@ namespace BugsnagUnityPerformance
 
         private void markPValueUpdated()
         {
-            _pValueTimeout = DateTime.Now.AddSeconds(_config.PValueTimeoutSeconds);
+            _pValueTimeout = DateTimeOffset.UtcNow.AddSeconds(_config.PValueTimeoutSeconds);
         }
 
         private void OnPValueRequestCompleted(TracePayload payload, UnityWebRequest req, double newProbability)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug Fixes
+
+- Fix an issue where DateTime.Now was used instead of DateTimeOffset.UtcNow during initialisation [#146](https://github.com/bugsnag/bugsnag-unity-performance/pull/146)
+
+
 ## v1.6.1 (2024-10-09)
 
 ### Bug Fixes


### PR DESCRIPTION
## Goal

The SDK uses DateTimeOffset.UtcNow at all times, but the P Value updater was mistakenly using local time which can cause app hangs on iOS.

## Testing

Covered by existing tests