### PR TITLE
CI pipeline tidy-up

### DIFF
--- a/.buildkite/block.yml
+++ b/.buildkite/block.yml
@@ -1,5 +1,5 @@
 agents:
-  queue: opensource
+  queue: macos
 
 steps:
   - block: 'Trigger a full build'
@@ -7,4 +7,5 @@ steps:
 
   - label: 'Upload the full test pipeline'
     depends_on: 'trigger-full-build'
+    timeout_in_minutes: 2
     command: buildkite-agent pipeline upload .buildkite/pipeline.full.yml

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -1,20 +1,24 @@
 agents:
-  queue: opensource
+  queue: macos
 
 steps:
-  - name: 'Append Unity 2020 Full Pipeline'
+  - label: 'Append Unity 2020 Full Pipeline'
+    timeout_in_minutes: 2
     commands:
       - buildkite-agent pipeline upload .buildkite/unity.2020.full.yml
 
-  - name: 'Append Unity 2021 Full Pipeline'
+  - label: 'Append Unity 2021 Full Pipeline'
+    timeout_in_minutes: 2
     commands:
       - buildkite-agent pipeline upload .buildkite/unity.2021.full.yml
 
-  - name: 'Append Unity 2022 Full Pipeline'
+  - label: 'Append Unity 2022 Full Pipeline'
+    timeout_in_minutes: 2
     commands:
       - buildkite-agent pipeline upload .buildkite/unity.2022.full.yml
 
-  - name: 'Append Unity 6000 Full Pipeline'
+  - label: 'Append Unity 6000 Full Pipeline'
+    timeout_in_minutes: 2
     commands:
       - buildkite-agent pipeline upload .buildkite/unity.6000.full.yml
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,7 +7,7 @@ agents:
 
 steps:
   - label: Build released library artifact
-    timeout_in_minutes: 30
+    timeout_in_minutes: 10
     key: build-artifacts
     env:
       UNITY_PERFORMANCE_VERSION: *2020
@@ -22,8 +22,8 @@ steps:
           limit: 1
 
   - label: Build size impact reporting
-    timeout_in_minutes: 10
     depends_on: build-artifacts
+    timeout_in_minutes: 10
     env:
       UNITY_PERFORMANCE_VERSION: *2021
     plugins:
@@ -33,10 +33,15 @@ steps:
     commands:
       features/scripts/do_size_test.sh
 
-  - name: 'Append Unity 2021 Basic Pipeline'
+  - label: 'Append Unity 2021 Basic Pipeline'
+    agents:
+      queue: macos
+    timeout_in_minutes: 2
     commands:
       - buildkite-agent pipeline upload .buildkite/unity.2021.yml
 
   - label: Conditionally trigger full set of tests
-    timeout_in_minutes: 30
+    agents:
+      queue: macos
+    timeout_in_minutes: 2
     command: sh -c .buildkite/pipeline_trigger.sh

--- a/.buildkite/unity.2020.full.yml
+++ b/.buildkite/unity.2020.full.yml
@@ -96,7 +96,7 @@ steps:
               limit: 1
 
       - label: ':ios: Build iOS test fixture for Unity 2020'
-        timeout_in_minutes: 30
+        timeout_in_minutes: 10
         key: build-ios-fixture-2020
         depends_on: generate-fixture-project-2020
         env:
@@ -125,7 +125,7 @@ steps:
   - group: ":test_tube: E2E Tests Unity 2020"
     steps:
       - label: Run MacOS e2e tests for Unity 2020
-        timeout_in_minutes: 60
+        timeout_in_minutes: 30
         depends_on: build-macos-fixture-2020
         env:
           UNITY_PERFORMANCE_VERSION: *2020

--- a/.buildkite/unity.2021.full.yml
+++ b/.buildkite/unity.2021.full.yml
@@ -8,7 +8,7 @@ steps:
   - group: ":hammer: Build Unity 2021 Test Fixtures"
     steps:
       - label: ':webgl: Build webgl DEV test fixture for Unity 2021'
-        timeout_in_minutes: 30
+        timeout_in_minutes: 15
         key: build-webgl-dev-fixture-2021
         depends_on: build-artifacts
         env:
@@ -52,7 +52,7 @@ steps:
               limit: 1
 
       - label: ':macos: Build macos DEV test fixture for Unity 2021'
-        timeout_in_minutes: 30
+        timeout_in_minutes: 10
         key: build-macos-dev-fixture-2021
         depends_on: build-artifacts
         env:
@@ -73,7 +73,7 @@ steps:
               limit: 1
 
       - label: ':ios: Generate Xcode DEV project - Unity 2021'
-        timeout_in_minutes: 30
+        timeout_in_minutes: 10
         key: generate-dev-fixture-project-2021
         depends_on: build-artifacts
         env:
@@ -95,7 +95,7 @@ steps:
               limit: 1
 
       - label: ':ios: Build iOS DEV test fixture for Unity 2021'
-        timeout_in_minutes: 30
+        timeout_in_minutes: 10
         key: build-ios-dev-fixture-2021
         depends_on: generate-dev-fixture-project-2021
         env:
@@ -119,7 +119,7 @@ steps:
   - group: ":test_tube: E2E Tests Unity 2021"
     steps:
       - label: Run WebGL DEV e2e tests for Unity 2021
-        timeout_in_minutes: 60
+        timeout_in_minutes: 20
         depends_on: build-webgl-dev-fixture-2021
         env:
           UNITY_PERFORMANCE_VERSION: *2021
@@ -159,7 +159,7 @@ steps:
           - features/scripts/run-windows-ci-tests.sh dev
 
       - label: ':android: Build Android Dev test fixture for Unity 2021'
-        timeout_in_minutes: 30
+        timeout_in_minutes: 10
         key: build-android-dev-fixture-2021
         depends_on: build-artifacts
         env:
@@ -181,7 +181,7 @@ steps:
               limit: 1
 
       - label: Run MacOS DEV e2e tests for Unity 2021
-        timeout_in_minutes: 60
+        timeout_in_minutes: 30
         depends_on: build-macos-dev-fixture-2021
         env:
           UNITY_PERFORMANCE_VERSION: *2021

--- a/.buildkite/unity.2021.yml
+++ b/.buildkite/unity.2021.yml
@@ -8,7 +8,7 @@ steps:
   - group: ":hammer: Build Unity 2021 Test Fixtures"
     steps:
       - label: ':webgl: Build webgl test fixture for Unity 2021'
-        timeout_in_minutes: 30
+        timeout_in_minutes: 10
         key: build-webgl-fixture-2021
         depends_on: build-artifacts
         env:
@@ -73,7 +73,7 @@ steps:
               limit: 1
 
       - label: ':android: Build Android test fixture for Unity 2021'
-        timeout_in_minutes: 30
+        timeout_in_minutes: 10
         key: build-android-fixture-2021
         depends_on: build-artifacts
         env:
@@ -95,7 +95,7 @@ steps:
               limit: 1
 
       - label: ':ios: Generate Xcode project - Unity 2021'
-        timeout_in_minutes: 30
+        timeout_in_minutes: 10
         key: generate-fixture-project-2021
         depends_on: build-artifacts
         env:
@@ -117,7 +117,7 @@ steps:
               limit: 1
 
       - label: ':ios: Build iOS test fixture for Unity 2021'
-        timeout_in_minutes: 30
+        timeout_in_minutes: 10
         key: build-ios-fixture-2021
         depends_on: generate-fixture-project-2021
         env:
@@ -141,7 +141,7 @@ steps:
   - group: ":test_tube: E2E Tests Unity 2021"
     steps:
       - label: Run WebGL e2e tests for Unity 2021
-        timeout_in_minutes: 60
+        timeout_in_minutes: 20
         depends_on: build-webgl-fixture-2021
         env:
           UNITY_PERFORMANCE_VERSION: *2021
@@ -185,7 +185,7 @@ steps:
           - features/scripts/run-windows-ci-tests.sh release
 
       - label: Run MacOS e2e tests for Unity 2021
-        timeout_in_minutes: 60
+        timeout_in_minutes: 30
         depends_on: build-macos-fixture-2021
         env:
           UNITY_PERFORMANCE_VERSION: *2021

--- a/.buildkite/unity.2022.full.yml
+++ b/.buildkite/unity.2022.full.yml
@@ -8,7 +8,7 @@ steps:
   - group: ":hammer: Build Unity 2022 Test Fixtures"
     steps:
       - label: ':macos: Build macos test fixture for Unity 2022'
-        timeout_in_minutes: 30
+        timeout_in_minutes: 20
         key: build-macos-fixture-2022
         depends_on: build-artifacts
         env:
@@ -52,7 +52,7 @@ steps:
               limit: 1
 
       - label: ':android: Build Android test fixture for Unity 2022'
-        timeout_in_minutes: 30
+        timeout_in_minutes: 10
         key: build-android-fixture-2022
         depends_on: build-artifacts
         env:
@@ -74,7 +74,7 @@ steps:
               limit: 1
 
       - label: ':ios: Generate Xcode project - Unity 2022'
-        timeout_in_minutes: 30
+        timeout_in_minutes: 10
         key: generate-fixture-project-2022
         depends_on: build-artifacts
         env:
@@ -96,7 +96,7 @@ steps:
               limit: 1
 
       - label: ':ios: Build iOS test fixture for Unity 2022'
-        timeout_in_minutes: 30
+        timeout_in_minutes: 10
         key: build-ios-fixture-2022
         depends_on: generate-fixture-project-2022
         env:
@@ -121,7 +121,7 @@ steps:
   - group: ":test_tube: E2E Tests Unity 2022"
     steps:
       - label: Run MacOS e2e tests for Unity 2022
-        timeout_in_minutes: 60
+        timeout_in_minutes: 30
         depends_on: build-macos-fixture-2022
         env:
           UNITY_PERFORMANCE_VERSION: *2022

--- a/.buildkite/unity.6000.full.yml
+++ b/.buildkite/unity.6000.full.yml
@@ -52,7 +52,7 @@ steps:
               limit: 1
 
       - label: ':android: Build Android test fixture for Unity 6000'
-        timeout_in_minutes: 30
+        timeout_in_minutes: 10
         key: build-android-fixture-6000
         depends_on: build-artifacts
         env:
@@ -74,7 +74,7 @@ steps:
               limit: 1
 
       - label: ':ios: Generate Xcode project - Unity 6000'
-        timeout_in_minutes: 30
+        timeout_in_minutes: 10
         key: generate-fixture-project-6000
         depends_on: build-artifacts
         env:
@@ -96,7 +96,7 @@ steps:
               limit: 1
 
       - label: ':ios: Build iOS test fixture for Unity 6000'
-        timeout_in_minutes: 30
+        timeout_in_minutes: 10
         key: build-ios-fixture-6000
         depends_on: generate-fixture-project-6000
         env:
@@ -121,7 +121,7 @@ steps:
   - group: ":test_tube: E2E Tests Unity 6000"
     steps:
       - label: Run MacOS e2e tests for Unity 6000
-        timeout_in_minutes: 60
+        timeout_in_minutes: 30
         depends_on: build-macos-fixture-6000
         env:
           UNITY_PERFORMANCE_VERSION: *6000


### PR DESCRIPTION
## Goal

General tidy-up of the Buildkite pipeline to:
- Ensure all steps have an adequate but not excessive timeout
- Agent queues are explicitly stated in each file (even if a default is used)
- Generic `macos` queue is used instead of specific macOS versions where possible

## Testing

Covered by a full CI run.