### PR TITLE
fix for missing assembly reference

### DIFF
--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/BugsnagPerformance.asmdef
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/BugsnagPerformance.asmdef
@@ -1,3 +1,16 @@
-﻿{
-	"name": "BugsnagPerformance"
+{
+    "name": "BugsnagPerformance",
+    "rootNamespace": "",
+    "references": [
+        "BugsnagUnity"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Bug Fixes
+
+- Fix an issue where using this SDK with v8.3.0+ the BugSnag Unity Notifier would cause an exception while trying to resolve the BugsnagUnityWebRequest wrapper [#151](https://github.com/bugsnag/bugsnag-unity-performance/pull/151)
+
 ## v1.7.0 (2024-11-14)
 
 ### Additions


### PR DESCRIPTION
## Goal

The latest Bugsnag Unity Notifier release [v8.3.0](https://github.com/bugsnag/bugsnag-unity/releases/tag/v8.3.0) broke the ability of the performance SDK to share the UnityWebRequest Wrapper as it now uses an assembly definition.

## Changeset

Added a reference to the new BugsnagUnity assembly defenition in the performance assembly definition. If the notifier is not present then it ignores to included reference.

## Testing

Full e2e and manually tested locally