### PR TITLE
Release v1.7.1

### DIFF
--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/BugsnagPerformance.asmdef
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/BugsnagPerformance.asmdef
@@ -1,3 +1,16 @@
-﻿{
-	"name": "BugsnagPerformance"
+{
+    "name": "BugsnagPerformance",
+    "rootNamespace": "",
+    "references": [
+        "BugsnagUnity"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Version.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Version.cs
@@ -3,6 +3,6 @@
     internal static class Version
     {
         //TODO set this using sed or something in the release automation task
-        public const string VersionString = "1.7.0";
+        public const string VersionString = "1.7.1";
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Bug Fixes
+
+- Fix an issue where using this SDK with v8.3.0+ the BugSnag Unity Notifier would cause an exception while trying to resolve the BugsnagUnityWebRequest wrapper [#151](https://github.com/bugsnag/bugsnag-unity-performance/pull/151)
+
 ## v1.7.0 (2024-11-14)
 
 ### Additions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## TBD
+## v1.7.1 (2024-12-06)
 
 ### Bug Fixes
 
-- Fix an issue where using this SDK with v8.3.0+ the BugSnag Unity Notifier would cause an exception while trying to resolve the BugsnagUnityWebRequest wrapper [#151](https://github.com/bugsnag/bugsnag-unity-performance/pull/151)
+- Fix an issue where using this SDK with v8.3.0+ of the BugSnag Unity Notifier would cause an exception while trying to resolve the BugsnagUnityWebRequest wrapper [#151](https://github.com/bugsnag/bugsnag-unity-performance/pull/151)
 
 ## v1.7.0 (2024-11-14)
 

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Network/NetworkPostFail.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Network/NetworkPostFail.cs
@@ -19,9 +19,19 @@ public class NetworkPostFail : Scenario
 
     private IEnumerator DoRun()
     {
+#if UNITY_2022_2_OR_NEWER
+        WWWForm form = new WWWForm();
+        form.AddField("data", "1234567890");
+        yield return BugsnagUnityWebRequest.Post(FAIL_URL, form).SendWebRequest();
+#else
         yield return BugsnagUnityWebRequest.Post(FAIL_URL, "1234567890").SendWebRequest();
+#endif
         yield return new WaitForSeconds(1);
-        BugsnagUnityWebRequest.Post(Main.MazeHost, "1234567890").SendWebRequest();
+#if UNITY_2022_2_OR_NEWER
+        yield return BugsnagUnityWebRequest.Post(Main.MazeHost, form).SendWebRequest();
+#else
+        yield return BugsnagUnityWebRequest.Post(Main.MazeHost, "1234567890").SendWebRequest();
+#endif
     }
 
 }

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Network/NetworkPostSuccess.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Network/NetworkPostSuccess.cs
@@ -14,7 +14,13 @@ public class NetworkPostSuccess : Scenario
 
     public override void Run()
     {
+    #if UNITY_2022_2_OR_NEWER
+        WWWForm form = new WWWForm();
+        form.AddField("data", "1234567890");
+        BugsnagUnityWebRequest.Post(Main.MazeHost, form).SendWebRequest();
+    #else
         BugsnagUnityWebRequest.Post(Main.MazeHost, "1234567890").SendWebRequest();
+    #endif
     }
 
 }


### PR DESCRIPTION
## v1.7.1 (2024-12-06)

### Bug Fixes

- Fix an issue where using this SDK with v8.3.0+ of the BugSnag Unity Notifier would cause an exception while trying to resolve the BugsnagUnityWebRequest wrapper [#151](https://github.com/bugsnag/bugsnag-unity-performance/pull/151)