### PR TITLE
send string.Empty if span name is null

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ features/fixtures/minimalapp/minimal_without_xcode
 features/fixtures/mazerunner/mazerunner_macos_BackUpThisFolder_ButDontShipItWithYourGame
 BugsnagPerformance/.vscode
 features/fixtures/mazerunner/Assets/Bugsnag
+features/fixtures/mazerunner/.vscode
+.DS_Store
+maze_output.zip

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/Span.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/Span.cs
@@ -29,7 +29,7 @@ namespace BugsnagUnityPerformance
 
         public Span(string name, SpanKind kind, string id, string traceId, string parentSpanId, DateTimeOffset startTime, bool? isFirstClass, OnSpanEnd onSpanEnd, int maxCustomAttributes)
         {
-            Name = name;
+            Name = name ?? string.Empty;
             Kind = kind;
             SpanId = id;
             TraceId = traceId;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Bug Fixes
+
+- Fix an issue where spans started with null names sent no name field. Now string.Empty will be sent instead [#154](https://github.com/bugsnag/bugsnag-unity-performance/pull/154)
+
 ## v1.7.1 (2024-12-06)
 
 ### Bug Fixes

--- a/features/fixtures/mazerunner/Assets/Scenes/MainScene.unity
+++ b/features/fixtures/mazerunner/Assets/Scenes/MainScene.unity
@@ -38,7 +38,6 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -269,6 +268,7 @@ GameObject:
   - component: {fileID: 259057445}
   - component: {fileID: 259057446}
   - component: {fileID: 259057447}
+  - component: {fileID: 259057448}
   m_Layer: 0
   m_Name: ManualSpans
   m_TagString: Untagged
@@ -314,6 +314,19 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: b1acdfac80082464180a997600222189, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ShouldStartNotifier: 0
+--- !u!114 &259057448
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 259057444}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 207dd502074ed4e0c8fde31423e1eb9d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   ShouldStartNotifier: 0
@@ -564,6 +577,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 552d75942a8b04b0cb4df3695b068649, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ShouldStartNotifier: 0
 --- !u!114 &323187835
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -576,6 +590,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cbb1313beb8e2452eb405afc7461767c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ShouldStartNotifier: 0
 --- !u!1 &368414949
 GameObject:
   m_ObjectHideFlags: 0

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Spans/NullSpanName.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Spans/NullSpanName.cs
@@ -1,0 +1,19 @@
+using BugsnagUnityPerformance;
+
+public class NullSpanName : Scenario
+{
+
+    public override void PreparePerformanceConfig(string apiKey, string host)
+    {
+        base.PreparePerformanceConfig(apiKey, host);
+        SetMaxBatchSize(2);
+    }
+
+    public override void Run()
+    {
+        base.Run();
+        BugsnagPerformance.StartSpan(null).End();
+        BugsnagPerformance.StartSpan("control").End();
+    }
+
+}

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Spans/NullSpanName.cs.meta
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Spans/NullSpanName.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 207dd502074ed4e0c8fde31423e1eb9d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -68,4 +68,10 @@ Feature: Manual creation of spans
     * the trace payload field "resourceSpans.0.resource" string attribute "host.arch" exists
     * the trace payload field "resourceSpans.0.resource" string attribute "bugsnag.app.bundle_version" exists
 
+  Scenario: null span name becomes empty string
+    When I run the game in the "NullSpanName" state
+    And I wait for 2 spans
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals ""
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.name" equals "control"
+
 


### PR DESCRIPTION
## Goal

Span names in custom spans were not null checked and so the sdk was reporting spans with no name field. 

Now we check and set the name to an empty string.

## Testing

Added new E2E test