### PR TITLE
add frame rate metrics

### DIFF
--- a/BugsnagPerformance/Assets/BugsnagPerformance/Editor/BugsnagPerformanceEditor.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Editor/BugsnagPerformanceEditor.cs
@@ -9,6 +9,8 @@ public class BugsnagPerformanceEditor : EditorWindow
 
     public Texture DarkIcon, LightIcon;
 
+    bool _showEnabledMetrics;
+
     private void OnEnable()
     {
         titleContent.text = "BugSnag Performance";
@@ -107,10 +109,33 @@ public class BugsnagPerformanceEditor : EditorWindow
         EditorGUILayout.PropertyField(so.FindProperty("Endpoint"));
         EditorGUILayout.PropertyField(so.FindProperty("ServiceName"));
         EditorGUILayout.PropertyField(so.FindProperty("TracePropagationUrls"));
+        DrawEnabledMetricsDropdown(so,settings);
         EditorGUI.indentLevel--;
         so.ApplyModifiedProperties();
         EditorUtility.SetDirty(settings);
     }
+
+    private void DrawEnabledMetricsDropdown(SerializedObject so, BugsnagPerformanceSettingsObject settings)
+    {
+        var style = new GUIStyle(GUI.skin.GetStyle("foldout"));
+        style.margin = new RectOffset(2, 0, 0, 0);
+        _showEnabledMetrics = EditorGUILayout.Foldout(_showEnabledMetrics, "Enabled Metrics", true, style);
+
+        if (_showEnabledMetrics)
+        {
+            EditorGUI.indentLevel += 2;
+
+            // Grab the property
+            var enabledMetricsProp = so.FindProperty("EnabledMetrics");
+            var renderingProp = enabledMetricsProp.FindPropertyRelative("Rendering");
+
+            // Draw the property so it’s serialized properly:
+            EditorGUILayout.PropertyField(renderingProp, new GUIContent("Rendering"));
+
+            EditorGUI.indentLevel -= 2;
+        }
+    }
+
 
     private void DrawIntPropertyWithDefault(SerializedObject so, string propertyName, string label, int defaultValue)
     {

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Editor/BugsnagPerformanceEditor.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Editor/BugsnagPerformanceEditor.cs
@@ -124,14 +124,9 @@ public class BugsnagPerformanceEditor : EditorWindow
         if (_showEnabledMetrics)
         {
             EditorGUI.indentLevel += 2;
-
-            // Grab the property
             var enabledMetricsProp = so.FindProperty("EnabledMetrics");
             var renderingProp = enabledMetricsProp.FindPropertyRelative("Rendering");
-
-            // Draw the property so it’s serialized properly:
             EditorGUILayout.PropertyField(renderingProp, new GUIContent("Rendering"));
-
             EditorGUI.indentLevel -= 2;
         }
     }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/FrameMetricsCollector.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/FrameMetricsCollector.cs
@@ -11,9 +11,9 @@ namespace BugsnagUnityPerformance
         private int FrozenFrames = 0;
         private float SlowFrameThreshold = 1.0f / (Application.targetFrameRate > 0 ? Application.targetFrameRate : 60.0f);
         private const float FROZEN_FRAME_THRESHOLD = 0.7f; // 700 ms
-
         private PlayerLoopSystem _playerUpdateCallback;
         private bool _isEnabled = true;
+        private bool _callbackActive = false;
 
         public FrameMetricsCollector()
         {
@@ -31,6 +31,7 @@ namespace BugsnagUnityPerformance
             systems.Insert(0, _playerUpdateCallback);
             playerLoop.subSystemList = systems.ToArray();
             PlayerLoop.SetPlayerLoop(playerLoop);
+            _callbackActive = true;
         }
 
         private void OnUnityUpdate()
@@ -50,7 +51,7 @@ namespace BugsnagUnityPerformance
 
         public FrameMetricsSnapshot TakeSnapshot()
         {
-            if(!_isEnabled)
+            if(!_isEnabled || !_callbackActive)
             {
                 return null;
             }
@@ -78,6 +79,7 @@ namespace BugsnagUnityPerformance
             systems.Remove(_playerUpdateCallback);
             playerLoop.subSystemList = systems.ToArray();
             PlayerLoop.SetPlayerLoop(playerLoop);
+            _callbackActive = false;
         }
 
         public void Start()

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/FrameMetricsCollector.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/FrameMetricsCollector.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.LowLevel;
+
+namespace BugsnagUnityPerformance
+{
+    internal class FrameMetricsCollector
+    {
+        private int TotalFrames = 0;
+        private int SlowFrames = 0;
+        private int FrozenFrames = 0;
+        private float SlowFrameThreshold = 1.0f / Application.targetFrameRate; // ~30 FPS
+        private const float FROZEN_FRAME_THRESHOLD = 0.7f; // 700 ms
+
+        public FrameMetricsCollector()
+        {
+            BeginCollectingMetrics();
+        }
+        private void BeginCollectingMetrics()
+        {
+            var playerLoop = PlayerLoop.GetCurrentPlayerLoop();
+            var newSystem = new PlayerLoopSystem
+            {
+                updateDelegate = OnUnityUpdate
+            };
+            var systems = new List<PlayerLoopSystem>(playerLoop.subSystemList);
+            systems.Insert(0, newSystem);
+            playerLoop.subSystemList = systems.ToArray();
+            PlayerLoop.SetPlayerLoop(playerLoop);
+        }
+
+        private void OnUnityUpdate()
+        {
+            float frameTime = Time.unscaledDeltaTime;
+            TotalFrames++;
+
+            if (frameTime >= FROZEN_FRAME_THRESHOLD)
+            {
+                FrozenFrames++;
+            }
+            else if (frameTime > SlowFrameThreshold)
+            {
+                SlowFrames++;
+            }
+        }
+
+        public FrameMetricsSnapshot TakeSnapshot()
+        {
+            return new FrameMetricsSnapshot
+            {
+                TotalFrames = TotalFrames,
+                SlowFrames = SlowFrames,
+                FrozenFrames = FrozenFrames
+            };
+        }
+    }
+
+    internal class FrameMetricsSnapshot
+    {
+        public int TotalFrames { get; set; }
+        public int SlowFrames { get; set; }
+        public int FrozenFrames { get; set; }
+    }
+}

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/FrameMetricsCollector.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/FrameMetricsCollector.cs
@@ -20,7 +20,6 @@ namespace BugsnagUnityPerformance
         }
         private void BeginCollectingMetrics()
         {
-            Debug.Log(Application.targetFrameRate);
             var playerLoop = PlayerLoop.GetCurrentPlayerLoop();
             _playerUpdateCallback= new PlayerLoopSystem
             {

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/FrameMetricsCollector.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/FrameMetricsCollector.cs
@@ -4,13 +4,16 @@ using UnityEngine.LowLevel;
 
 namespace BugsnagUnityPerformance
 {
-    internal class FrameMetricsCollector
+    internal class FrameMetricsCollector : IPhasedStartup
     {
         private int TotalFrames = 0;
         private int SlowFrames = 0;
         private int FrozenFrames = 0;
-        private float SlowFrameThreshold = 1.0f / Application.targetFrameRate; // ~30 FPS
+        private float SlowFrameThreshold = 1.0f / (Application.targetFrameRate > 0 ? Application.targetFrameRate : 60.0f);
         private const float FROZEN_FRAME_THRESHOLD = 0.7f; // 700 ms
+
+        private PlayerLoopSystem _playerUpdateCallback;
+        private bool _isEnabled = true;
 
         public FrameMetricsCollector()
         {
@@ -18,13 +21,14 @@ namespace BugsnagUnityPerformance
         }
         private void BeginCollectingMetrics()
         {
+            Debug.Log(Application.targetFrameRate);
             var playerLoop = PlayerLoop.GetCurrentPlayerLoop();
-            var newSystem = new PlayerLoopSystem
+            _playerUpdateCallback= new PlayerLoopSystem
             {
                 updateDelegate = OnUnityUpdate
             };
             var systems = new List<PlayerLoopSystem>(playerLoop.subSystemList);
-            systems.Insert(0, newSystem);
+            systems.Insert(0, _playerUpdateCallback);
             playerLoop.subSystemList = systems.ToArray();
             PlayerLoop.SetPlayerLoop(playerLoop);
         }
@@ -46,6 +50,10 @@ namespace BugsnagUnityPerformance
 
         public FrameMetricsSnapshot TakeSnapshot()
         {
+            if(!_isEnabled)
+            {
+                return null;
+            }
             return new FrameMetricsSnapshot
             {
                 TotalFrames = TotalFrames,
@@ -53,9 +61,32 @@ namespace BugsnagUnityPerformance
                 FrozenFrames = FrozenFrames
             };
         }
+
+        public void Configure(PerformanceConfiguration config)
+        {
+            _isEnabled = config.EnabledMetrics.Rendering;
+            if(!_isEnabled)
+            {
+                RemoveUpdateCallback();
+            }
+        }
+
+        private void RemoveUpdateCallback()
+        {
+            var playerLoop = PlayerLoop.GetCurrentPlayerLoop();
+            var systems = new List<PlayerLoopSystem>(playerLoop.subSystemList);
+            systems.Remove(_playerUpdateCallback);
+            playerLoop.subSystemList = systems.ToArray();
+            PlayerLoop.SetPlayerLoop(playerLoop);
+        }
+
+        public void Start()
+        {
+            //do nothing
+        }
     }
 
-    internal class FrameMetricsSnapshot
+    public class FrameMetricsSnapshot
     {
         public int TotalFrames { get; set; }
         public int SlowFrames { get; set; }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/FrameMetricsCollector.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/FrameMetricsCollector.cs
@@ -9,7 +9,6 @@ namespace BugsnagUnityPerformance
         private int TotalFrames = 0;
         private int SlowFrames = 0;
         private int FrozenFrames = 0;
-        private float SlowFrameThreshold = 1.0f / (Application.targetFrameRate > 0 ? Application.targetFrameRate : 60.0f);
         private const float FROZEN_FRAME_THRESHOLD = 0.7f; // 700 ms
         private PlayerLoopSystem _playerUpdateCallback;
         private bool _isEnabled = true;
@@ -36,14 +35,18 @@ namespace BugsnagUnityPerformance
 
         private void OnUnityUpdate()
         {
-            float frameTime = Time.unscaledDeltaTime;
             TotalFrames++;
-
+            float frameTime = Time.unscaledDeltaTime;
             if (frameTime >= FROZEN_FRAME_THRESHOLD)
             {
                 FrozenFrames++;
+                return;
             }
-            else if (frameTime > SlowFrameThreshold)
+
+            // this cannot be a cached value as target frame rate can change at any time
+            var slowFrameThreshold = 1.0f / (Application.targetFrameRate > 0 ? Application.targetFrameRate : 60.0f);
+
+            if (frameTime > slowFrameThreshold)
             {
                 SlowFrames++;
             }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/FrameMetricsCollector.cs.meta
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/FrameMetricsCollector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 784bf8414f4b14bd194b367821da2e4e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/SpanFactory.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/SpanFactory.cs
@@ -12,9 +12,8 @@ namespace BugsnagUnityPerformance
 
         [ThreadStatic]
         private static Stack<WeakReference<ISpanContext>> _contextStack;
-
+        FrameMetricsCollector _frameMetricsCollector;
         private RNGCryptoServiceProvider _rNGCryptoServiceProvider = new RNGCryptoServiceProvider();
-
         private OnSpanEnd _onSpanEnd;
 
         private const string CONNECTION_TYPE_UNAVAILABLE = "unavailable";
@@ -27,9 +26,10 @@ namespace BugsnagUnityPerformance
 
         private int _maxCustomAttributes = PerformanceConfiguration.DEFAULT_ATTRIBUTE_COUNT_LIMIT;
 
-        public SpanFactory(OnSpanEnd onSpanEnd)
+        public SpanFactory(OnSpanEnd onSpanEnd, FrameMetricsCollector frameMetricsCollector)
         {
             _onSpanEnd = onSpanEnd;
+            _frameMetricsCollector = frameMetricsCollector;
             MainThreadDispatchBehaviour.Instance().StartCoroutine(GetConnectionType());
         }
 
@@ -106,8 +106,10 @@ namespace BugsnagUnityPerformance
                     traceId = GetNewTraceId();
                 }
             }
-
-            var newSpan = new Span(name, kind, spanId, traceId, parentSpanId, spanOptions.StartTime, spanOptions.IsFirstClass, _onSpanEnd, _maxCustomAttributes);
+            var newSpan = new Span(name, kind, spanId, 
+            traceId, parentSpanId, spanOptions.StartTime, 
+            spanOptions.IsFirstClass, _onSpanEnd, _maxCustomAttributes, 
+            _frameMetricsCollector.TakeSnapshot());
             if (spanOptions.MakeCurrentContext)
             {
                 AddToContextStack(newSpan);

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Tracer.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Tracer.cs
@@ -9,6 +9,7 @@ namespace BugsnagUnityPerformance
     internal class Tracer : IPhasedStartup
     {
         private PerformanceConfiguration _config;
+        private FrameMetricsCollector _frameMetricsCollector;
         private List<Span> _finishedSpanQueue = new List<Span>();
         private List<WeakReference<Span>> _preStartSpans = new List<WeakReference<Span>>();
         private object _queueLock = new object();
@@ -19,10 +20,11 @@ namespace BugsnagUnityPerformance
         private Delivery _delivery;
         private bool _started;
 
-        public Tracer(Sampler sampler, Delivery delivery)
+        public Tracer(Sampler sampler, Delivery delivery, FrameMetricsCollector frameMetricsCollector)
         {
             _sampler = sampler;
             _delivery = delivery;
+            _frameMetricsCollector = frameMetricsCollector;
         }
 
         public void Configure(PerformanceConfiguration config)
@@ -79,6 +81,7 @@ namespace BugsnagUnityPerformance
 
         public void OnSpanEnd(Span span)
         {
+            ApplyFrameRateMetrics(span);
             if (!_started)
             {
                 lock (_prestartLock)
@@ -91,6 +94,11 @@ namespace BugsnagUnityPerformance
             {
                 Sample(span);
             }
+        }
+
+        private void ApplyFrameRateMetrics(Span span)
+        {
+            span.ApplyFrameRateMetrics(_frameMetricsCollector.TakeSnapshot());
         }
 
         public void RunOnEndCallbacks(Span span)

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Tracer.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Tracer.cs
@@ -62,7 +62,7 @@ namespace BugsnagUnityPerformance
                     {
                         continue;
                     }
-                    if(!_config.EnabledMetrics.Rendering)
+                    if(_config.EnabledMetrics != null && ! _config.EnabledMetrics.Rendering)
                     {
                         span.RemoveFrameRateMetrics();
                     }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Tracer.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Tracer.cs
@@ -62,6 +62,10 @@ namespace BugsnagUnityPerformance
                     {
                         continue;
                     }
+                    if(!_config.EnabledMetrics.Rendering)
+                    {
+                        span.RemoveFrameRateMetrics();
+                    }
                     Sample(span);
                 }
             }
@@ -98,7 +102,7 @@ namespace BugsnagUnityPerformance
 
         private void ApplyFrameRateMetrics(Span span)
         {
-            span.ApplyFrameRateMetrics(_frameMetricsCollector.TakeSnapshot());
+            span.CalculateFrameRateMetrics(_frameMetricsCollector.TakeSnapshot());
         }
 
         public void RunOnEndCallbacks(Span span)

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Native/AndroidNative.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Native/AndroidNative.cs
@@ -97,7 +97,9 @@ namespace BugsnagUnityPerformance
                 return version.GetStatic<string>("RELEASE");
             }
 #endif
+#pragma warning disable CS0162 // Unreachable code detected
             return string.Empty;
+#pragma warning restore CS0162 // Unreachable code detected
         }
 
     }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformance.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformance.cs
@@ -136,14 +136,15 @@ namespace BugsnagUnityPerformance
             _sampler = new Sampler(_persistentState);
             _resourceModel = new ResourceModel(_cacheManager);
             _delivery = new Delivery(_resourceModel, _cacheManager, OnProbabilityChanged);
-            _tracer = new Tracer(_sampler, _delivery);
-            _spanFactory = new SpanFactory(_tracer.OnSpanEnd);
+            _tracer = new Tracer(_sampler, _delivery, _frameMetricsCollector);
+            _spanFactory = new SpanFactory(_tracer.OnSpanEnd, _frameMetricsCollector);
             _appStartHandler = new AppStartHandler(_spanFactory);
             _pValueUpdater = new PValueUpdater(_delivery, _sampler);
         }
 
         private void Configure(PerformanceConfiguration config)
         {
+            _frameMetricsCollector.Configure(config);
             _spanFactory.Configure(config);
             _networkRequestCallback = config.NetworkRequestCallback;
             _cacheManager.Configure(config);

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformance.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformance.cs
@@ -28,6 +28,7 @@ namespace BugsnagUnityPerformance
         private AppStartHandler _appStartHandler;
         private PersistentState _persistentState;
         private PValueUpdater _pValueUpdater;
+        private FrameMetricsCollector _frameMetricsCollector;
         private static List<WeakReference<Span>> _potentiallyOpenSpans = new List<WeakReference<Span>>();
         private Func<BugsnagNetworkRequestInfo, BugsnagNetworkRequestInfo> _networkRequestCallback;
 
@@ -131,6 +132,7 @@ namespace BugsnagUnityPerformance
         {
             _cacheManager = new CacheManager(Application.persistentDataPath);
             _persistentState = new PersistentState(_cacheManager);
+            _frameMetricsCollector = new FrameMetricsCollector();
             _sampler = new Sampler(_persistentState);
             _resourceModel = new ResourceModel(_cacheManager);
             _delivery = new Delivery(_resourceModel, _cacheManager, OnProbabilityChanged);

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformanceSettingsObject.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformanceSettingsObject.cs
@@ -31,8 +31,7 @@ namespace BugsnagUnityPerformance
         public int AttributeStringValueLimit;
         public int AttributeArrayLengthLimit;
         public int AttributeCountLimit;
-
-
+        public EnabledMetrics EnabledMetrics = new EnabledMetrics();
 
         public bool GenerateAnonymousId = true;
 
@@ -88,7 +87,7 @@ namespace BugsnagUnityPerformance
             {
                 config.AttributeCountLimit = AttributeCountLimit;
             }
-
+            config.EnabledMetrics = EnabledMetrics;
         }
 
         private Regex[] ConvertTracePropagationUrls(string[] urls)

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
@@ -8,6 +8,7 @@ using UnityEngine;
 
 namespace BugsnagUnityPerformance
 {
+    [Serializable]
     public class EnabledMetrics
     {
         public bool Rendering = false;

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
@@ -8,6 +8,10 @@ using UnityEngine;
 
 namespace BugsnagUnityPerformance
 {
+    public class EnabledMetrics
+    {
+        public bool Rendering = false;
+    }
     public class PerformanceConfiguration
     {
 
@@ -19,6 +23,7 @@ namespace BugsnagUnityPerformance
         private const int MAXIMUM_ATTRIBUTE_ARRAY_LENGTH_LIMIT = 10000;
         internal const int DEFAULT_ATTRIBUTE_COUNT_LIMIT = 128;
         private const int MAXIMUM_ATTRIBUTE_COUNT_LIMIT = 1000;
+
 
         public PerformanceConfiguration(string apiKey)
         {
@@ -98,8 +103,9 @@ namespace BugsnagUnityPerformance
 
         public string[] EnabledReleaseStages;
 
-        public string Endpoint = string.Empty;
+        public EnabledMetrics EnabledMetrics = new EnabledMetrics();
 
+        public string Endpoint = string.Empty;
 
         public Func<BugsnagNetworkRequestInfo, BugsnagNetworkRequestInfo> NetworkRequestCallback;
 

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/Span.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/Span.cs
@@ -27,7 +27,12 @@ namespace BugsnagUnityPerformance
         private int _customAttributeCount;
         private int _maxCustomAttributes;
 
-        public Span(string name, SpanKind kind, string id, string traceId, string parentSpanId, DateTimeOffset startTime, bool? isFirstClass, OnSpanEnd onSpanEnd, int maxCustomAttributes)
+        private FrameMetricsSnapshot _startFrameRateMetricsSnapshot;
+
+        public Span(string name, SpanKind kind, string id, 
+        string traceId, string parentSpanId, DateTimeOffset startTime, 
+        bool? isFirstClass, OnSpanEnd onSpanEnd, int maxCustomAttributes,
+        FrameMetricsSnapshot startFrameRateMetricsSnapshot)
         {
             Name = name ?? string.Empty;
             Kind = kind;
@@ -41,6 +46,7 @@ namespace BugsnagUnityPerformance
             {
                 SetAttributeInternal("bugsnag.span.first_class", isFirstClass.Value);
             }
+            _startFrameRateMetricsSnapshot = startFrameRateMetricsSnapshot;
             _onSpanEnd = onSpanEnd;
         }
 
@@ -213,6 +219,17 @@ namespace BugsnagUnityPerformance
         internal void SetCallbackComplete()
         {
             _callbackComplete = true;
+        }
+
+        internal void ApplyFrameRateMetrics(FrameMetricsSnapshot endFrameRateMetricsSnapshot)
+        {
+            if(_startFrameRateMetricsSnapshot == null || endFrameRateMetricsSnapshot == null)
+            {
+                return;
+            }
+            SetAttributeInternal("bugsnag.framerate.frozen_frames", endFrameRateMetricsSnapshot.FrozenFrames - _startFrameRateMetricsSnapshot.FrozenFrames);
+            SetAttributeInternal("bugsnag.framerate.slow_frames", endFrameRateMetricsSnapshot.SlowFrames - _startFrameRateMetricsSnapshot.SlowFrames);
+            SetAttributeInternal("bugsnag.framerate.total_frames", endFrameRateMetricsSnapshot.TotalFrames - _startFrameRateMetricsSnapshot.TotalFrames);
         }
     }
 }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/Span.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/Span.cs
@@ -26,7 +26,6 @@ namespace BugsnagUnityPerformance
         internal int DroppedAttributesCount;
         private int _customAttributeCount;
         private int _maxCustomAttributes;
-
         private FrameMetricsSnapshot _startFrameRateMetricsSnapshot;
 
         public Span(string name, SpanKind kind, string id, 
@@ -221,7 +220,7 @@ namespace BugsnagUnityPerformance
             _callbackComplete = true;
         }
 
-        internal void ApplyFrameRateMetrics(FrameMetricsSnapshot endFrameRateMetricsSnapshot)
+        internal void CalculateFrameRateMetrics(FrameMetricsSnapshot endFrameRateMetricsSnapshot)
         {
             if(_startFrameRateMetricsSnapshot == null || endFrameRateMetricsSnapshot == null)
             {
@@ -230,6 +229,13 @@ namespace BugsnagUnityPerformance
             SetAttributeInternal("bugsnag.framerate.frozen_frames", endFrameRateMetricsSnapshot.FrozenFrames - _startFrameRateMetricsSnapshot.FrozenFrames);
             SetAttributeInternal("bugsnag.framerate.slow_frames", endFrameRateMetricsSnapshot.SlowFrames - _startFrameRateMetricsSnapshot.SlowFrames);
             SetAttributeInternal("bugsnag.framerate.total_frames", endFrameRateMetricsSnapshot.TotalFrames - _startFrameRateMetricsSnapshot.TotalFrames);
+        }
+
+        internal void RemoveFrameRateMetrics()
+        {
+            _attributes.Remove("bugsnag.framerate.frozen_frames");
+            _attributes.Remove("bugsnag.framerate.slow_frames");
+            _attributes.Remove("bugsnag.framerate.total_frames");
         }
     }
 }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/SpanOptions.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/SpanOptions.cs
@@ -7,5 +7,6 @@ namespace BugsnagUnityPerformance
         public ISpanContext ParentContext = null;
         public bool MakeCurrentContext = true;
         public bool? IsFirstClass = null;
+        public bool? InstrumentRendering = null;
     }
 }

--- a/BugsnagPerformance/Assets/Scripts/Main.cs
+++ b/BugsnagPerformance/Assets/Scripts/Main.cs
@@ -12,12 +12,9 @@ public class Main : MonoBehaviour
 
     public void Start()
     {
-        // var config = BugsnagPerformanceSettingsObject.LoadConfiguration();
-        // config.AddOnSpanEnd((span) => {
-        //     Debug.Log("Span ended: " + span.Name);
-        //     return true;
-        // });
-        // BugsnagPerformance.Start(config);
+        var config = BugsnagPerformanceSettingsObject.LoadConfiguration();
+        config.EnabledMetrics.Rendering = true;
+        BugsnagPerformance.Start(config);
     }
 
     public void DoSpan()
@@ -52,7 +49,7 @@ public class Main : MonoBehaviour
         span.SetAttribute("my double attribute", 3.14);
         span.SetAttribute("my double[] attribute", new double[]{1.1, 2.2, 3.3});
 
-        yield return new WaitForSeconds(0.1f);
+        yield return new WaitForSeconds(1.0f);
         span.End();
     }
 

--- a/BugsnagPerformance/Assets/Scripts/Main.cs
+++ b/BugsnagPerformance/Assets/Scripts/Main.cs
@@ -12,12 +12,12 @@ public class Main : MonoBehaviour
 
     public void Start()
     {
-        var config = BugsnagPerformanceSettingsObject.LoadConfiguration();
-        config.AddOnSpanEnd((span) => {
-            Debug.Log("Span ended: " + span.Name);
-            return true;
-        });
-        BugsnagPerformance.Start(config);
+        // var config = BugsnagPerformanceSettingsObject.LoadConfiguration();
+        // config.AddOnSpanEnd((span) => {
+        //     Debug.Log("Span ended: " + span.Name);
+        //     return true;
+        // });
+        // BugsnagPerformance.Start(config);
     }
 
     public void DoSpan()

--- a/BugsnagPerformance/Assets/UnitTests/ConfigurationTests.cs
+++ b/BugsnagPerformance/Assets/UnitTests/ConfigurationTests.cs
@@ -82,7 +82,8 @@ namespace Tests
                 CustomStartTime,
                 true,
                 OnSpanEnd,
-                128);
+                128,
+                null);
             span.End(CustomEndTime);
             Assert.AreEqual(span.StartTime, CustomStartTime);
             Assert.AreEqual(span.EndTime, CustomEndTime);

--- a/BugsnagPerformance/Assets/UnitTests/SamplerTests.cs
+++ b/BugsnagPerformance/Assets/UnitTests/SamplerTests.cs
@@ -52,7 +52,8 @@ namespace Tests
                 DateTimeOffset.Now,
                 true,
                 OnSpanEnd,
-                128);
+                128,
+                null);
 
             Assert.AreEqual(1.0, sampler.Probability);
             Assert.IsTrue(sampler.Sampled(span));
@@ -91,7 +92,8 @@ namespace Tests
                 DateTimeOffset.Now,
                 true,
                 OnSpanEnd,
-                128);
+                128,
+                null);
 
             Assert.IsTrue(sampler.Sampled(span));
         }
@@ -111,7 +113,8 @@ namespace Tests
                 DateTimeOffset.Now,
                 true,
                 OnSpanEnd,
-                128);
+                128,
+                null);
 
             Assert.IsFalse(sampler.Sampled(span));
         }
@@ -131,7 +134,8 @@ namespace Tests
                 DateTimeOffset.Now,
                 true,
                 OnSpanEnd,
-                128);
+                128,
+                null);
 
             Assert.IsFalse(sampler.Sampled(span));
 
@@ -143,7 +147,8 @@ namespace Tests
                 DateTimeOffset.Now,
                 true,
                 OnSpanEnd,
-                128);
+                128,
+                null);
             Assert.IsTrue(sampler.Sampled(span));
 
         }
@@ -163,7 +168,8 @@ namespace Tests
                 DateTimeOffset.Now,
                 true,
                 OnSpanEnd,
-                128);
+                128,
+                null);
 
             Assert.IsTrue(sampler.Sampled(span));
 
@@ -175,7 +181,8 @@ namespace Tests
                 DateTimeOffset.Now,
                 true,
                 OnSpanEnd,
-                128);
+                128,
+                null);
             Assert.IsTrue(sampler.Sampled(span));
 
             span = new Span("test",
@@ -186,7 +193,8 @@ namespace Tests
                 DateTimeOffset.Now,
                 true,
                 OnSpanEnd,
-                128);
+                128,
+                null);
             Assert.IsFalse(sampler.Sampled(span));
 
         }

--- a/BugsnagPerformance/Assets/UnitTests/TracePayloadTests.cs
+++ b/BugsnagPerformance/Assets/UnitTests/TracePayloadTests.cs
@@ -126,7 +126,8 @@ namespace Tests
                             DateTimeOffset.Now,
                             true,
                             OnSpanEnd,
-                            128);
+                            128,
+                null);
             span.UpdateSamplingProbability(probability);
             return span;
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## TBD
 
+### Additions
+
+- Add frame rate metrics to spans. [#155](https://github.com/bugsnag/bugsnag-unity-performance/pull/155)
+
 ### Bug Fixes
 
 - Fix an issue where spans started with null names sent no name field. Now string.Empty will be sent instead [#154](https://github.com/bugsnag/bugsnag-unity-performance/pull/154)

--- a/features/fixtures/mazerunner/Assets/Scenes/MainScene.unity
+++ b/features/fixtures/mazerunner/Assets/Scenes/MainScene.unity
@@ -1007,6 +1007,51 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ShouldStartNotifier: 0
+--- !u!1 &1124192952
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1124192953}
+  - component: {fileID: 1124192954}
+  m_Layer: 0
+  m_Name: RenderingMetrics
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1124192953
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1124192952}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1294582014}
+  m_RootOrder: 12
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1124192954
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1124192952}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f27634f25651d46a09781bbb26568b33, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ShouldStartNotifier: 0
 --- !u!1 &1294582013
 GameObject:
   m_ObjectHideFlags: 0
@@ -1047,6 +1092,7 @@ Transform:
   - {fileID: 260121134}
   - {fileID: 323187831}
   - {fileID: 923005100}
+  - {fileID: 1124192953}
   m_Father: {fileID: 2126837007}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/features/fixtures/mazerunner/Assets/Scenes/MainScene.unity
+++ b/features/fixtures/mazerunner/Assets/Scenes/MainScene.unity
@@ -1017,6 +1017,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1124192953}
   - component: {fileID: 1124192954}
+  - component: {fileID: 1124192955}
   m_Layer: 0
   m_Name: RenderingMetrics
   m_TagString: Untagged
@@ -1052,6 +1053,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ShouldStartNotifier: 0
+--- !u!114 &1124192955
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1124192952}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6bb1e5e240fc2429482d20d392b88135, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1294582013
 GameObject:
   m_ObjectHideFlags: 0

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Metrics/ConfigureRenderMetrics.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Metrics/ConfigureRenderMetrics.cs
@@ -1,0 +1,39 @@
+using System.Collections;
+using BugsnagUnityPerformance;
+using UnityEngine;
+
+public class ConfigureRenderMetrics : Scenario
+{
+
+    Span _beforeStartSpan;
+
+    public override void PreparePerformanceConfig(string apiKey, string host)
+    {
+        base.PreparePerformanceConfig(apiKey, host);
+        SetMaxBatchSize(1);
+        Configuration.EnabledMetrics.Rendering = false;
+    }
+
+    public override void StartBugsnag()
+    {
+        _beforeStartSpan = BugsnagPerformance.StartSpan("BeforeStart");
+    }
+
+    public override void Run()
+    {
+        base.Run();
+        StartCoroutine(DoTest());
+    }
+
+    private IEnumerator DoTest()
+    {
+        yield return new WaitForSeconds(2.5f);
+        _beforeStartSpan.End();
+        yield return new WaitForSeconds(2.5f);
+        base.StartBugsnag();
+    }
+
+
+}
+
+

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Metrics/ConfigureRenderMetrics.cs.meta
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Metrics/ConfigureRenderMetrics.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6bb1e5e240fc2429482d20d392b88135
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Metrics/RenderMetrics.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Metrics/RenderMetrics.cs
@@ -9,6 +9,8 @@ public class RenderMetrics : Scenario
     int _slowFramesDone;
     Span _slowFrameSpan, _noFramesSpan, _disableInSpanOptionsSpan;
 
+    int _frameCount = 0;
+
     public override void PreparePerformanceConfig(string apiKey, string host)
     {
         base.PreparePerformanceConfig(apiKey, host);
@@ -28,7 +30,6 @@ public class RenderMetrics : Scenario
         _slowFrameSpan = BugsnagPerformance.StartSpan("SlowFrames");
         _noFramesSpan = BugsnagPerformance.StartSpan("NoFrames", new SpanOptions { IsFirstClass = false });
         _disableInSpanOptionsSpan = BugsnagPerformance.StartSpan("DisableInSpanOptions", new SpanOptions { InstrumentRendering = false });
-        yield return new WaitForSeconds(1);
         _doTenSlowFrames = true;
     }
 
@@ -42,6 +43,11 @@ public class RenderMetrics : Scenario
 
     void Update()
     {
+        _frameCount++;
+        if(_frameCount < 101)
+        {
+            return;
+        }
         if (_doTenSlowFrames)
         {
             if (_slowFramesDone < 10)

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Metrics/RenderMetrics.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Metrics/RenderMetrics.cs
@@ -1,0 +1,74 @@
+using System.Collections;
+using System.Threading;
+using BugsnagUnityPerformance;
+using UnityEngine;
+
+public class RenderMetrics : Scenario
+{
+    bool _doTenSlowFrames;
+    int _slowFramesDone;
+    Span _slowFrameSpan, _noFramesSpan;
+
+    public override void PreparePerformanceConfig(string apiKey, string host)
+    {
+        base.PreparePerformanceConfig(apiKey, host);
+        SetMaxBatchSize(2);
+        Configuration.EnabledMetrics.Rendering = true;
+    }
+
+    public override void Run()
+    {
+        base.Run();
+        StartCoroutine(StartTest());
+    }
+
+    private IEnumerator StartTest()
+    {
+        _slowFrameSpan = BugsnagPerformance.StartSpan("SlowFrames");
+        _noFramesSpan = BugsnagPerformance.StartSpan("NoFrames", new SpanOptions { IsFirstClass = false });
+        yield return new WaitForSeconds(1);
+        _doTenSlowFrames = true;
+    }
+
+    private IEnumerator EndTest()
+    {
+        yield return new WaitForSeconds(1);
+        _slowFrameSpan.End();
+        _noFramesSpan.End();
+    }
+
+    void Update()
+    {
+        if (_doTenSlowFrames)
+        {
+            if (_slowFramesDone < 10)
+            {
+                float startTime = Time.realtimeSinceStartup;
+
+                // Simulate a busy workload by blocking the main thread
+                while (Time.realtimeSinceStartup < startTime + 0.25f)
+                {
+                    // Do nothing, just burn CPU cycles
+                }
+                _slowFramesDone++;
+                return;
+            }
+            else
+            {
+                float startTime = Time.realtimeSinceStartup;
+
+                // Simulate a busy workload by blocking the main thread
+                while (Time.realtimeSinceStartup < startTime + 5)
+                {
+                    // Do nothing, just burn CPU cycles
+                }
+                // Thread.Sleep(1000); // frozen frame
+                _doTenSlowFrames = false;
+                StartCoroutine(EndTest());
+            }
+        }
+    }
+
+}
+
+

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Metrics/RenderMetrics.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Metrics/RenderMetrics.cs
@@ -7,7 +7,7 @@ public class RenderMetrics : Scenario
 {
     bool _doTenSlowFrames;
     int _slowFramesDone;
-    Span _slowFrameSpan, _noFramesSpan;
+    Span _slowFrameSpan, _noFramesSpan, _disableInSpanOptionsSpan;
 
     public override void PreparePerformanceConfig(string apiKey, string host)
     {
@@ -26,6 +26,7 @@ public class RenderMetrics : Scenario
     {
         _slowFrameSpan = BugsnagPerformance.StartSpan("SlowFrames");
         _noFramesSpan = BugsnagPerformance.StartSpan("NoFrames", new SpanOptions { IsFirstClass = false });
+        _disableInSpanOptionsSpan = BugsnagPerformance.StartSpan("DisableInSpanOptions", new SpanOptions { InstrumentRendering = false });
         yield return new WaitForSeconds(1);
         _doTenSlowFrames = true;
     }
@@ -35,6 +36,7 @@ public class RenderMetrics : Scenario
         yield return new WaitForSeconds(1);
         _slowFrameSpan.End();
         _noFramesSpan.End();
+        _disableInSpanOptionsSpan.End();
     }
 
     void Update()

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Metrics/RenderMetrics.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Metrics/RenderMetrics.cs
@@ -12,7 +12,7 @@ public class RenderMetrics : Scenario
     public override void PreparePerformanceConfig(string apiKey, string host)
     {
         base.PreparePerformanceConfig(apiKey, host);
-        SetMaxBatchSize(2);
+        SetMaxBatchSize(3);
         Configuration.EnabledMetrics.Rendering = true;
     }
 
@@ -24,6 +24,7 @@ public class RenderMetrics : Scenario
 
     private IEnumerator StartTest()
     {
+        yield return new WaitForSeconds(3);
         _slowFrameSpan = BugsnagPerformance.StartSpan("SlowFrames");
         _noFramesSpan = BugsnagPerformance.StartSpan("NoFrames", new SpanOptions { IsFirstClass = false });
         _disableInSpanOptionsSpan = BugsnagPerformance.StartSpan("DisableInSpanOptions", new SpanOptions { InstrumentRendering = false });

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Metrics/RenderMetrics.cs.meta
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Metrics/RenderMetrics.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f27634f25651d46a09781bbb26568b33
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/rendering_metrics.feature
+++ b/features/rendering_metrics.feature
@@ -5,7 +5,7 @@ Feature: Rendering Metrics
 
   Scenario: Frame Rate Metrics
     When I run the game in the "RenderMetrics" state
-    And I wait for 2 spans
+    And I wait for 3 spans
     
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "SlowFrames"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes" is an array with 7 elements
@@ -15,7 +15,13 @@ Feature: Rendering Metrics
 
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.name" equals "NoFrames"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.attributes" is an array with 4 elements
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" boolean attribute "bugsnag.span.first_class" is false
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" string attribute "bugsnag.span.category" equals "custom"
 
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.2.name" equals "DisableInSpanOptions"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.2.attributes" is an array with 4 elements
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.2" boolean attribute "bugsnag.span.first_class" is true
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.2" string attribute "bugsnag.span.category" equals "custom"
 
 
   Scenario: Disable Frame Rate Metrics

--- a/features/rendering_metrics.feature
+++ b/features/rendering_metrics.feature
@@ -31,12 +31,3 @@ Feature: Rendering Metrics
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes" is an array with 4 elements
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" boolean attribute "bugsnag.span.first_class" is true
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "custom"
-
-
-
-
-
-
-
-
-

--- a/features/rendering_metrics.feature
+++ b/features/rendering_metrics.feature
@@ -1,0 +1,26 @@
+Feature: Rendering Metrics
+
+  Background:
+    Given I clear the Bugsnag cache
+
+  Scenario: Frame Rate Metrics
+    When I run the game in the "RenderMetrics" state
+    And I wait for 2 spans
+    
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "SlowFrames"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes" is an array with 7 elements
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "bugsnag.framerate.frozen_frames" equals 1
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "bugsnag.framerate.slow_frames" is greater than 10
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "bugsnag.framerate.total_frames" is greater than 100
+
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.name" equals "NoFrames"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.attributes" is an array with 4 elements
+
+
+
+
+
+
+
+
+

--- a/features/rendering_metrics.feature
+++ b/features/rendering_metrics.feature
@@ -18,6 +18,16 @@ Feature: Rendering Metrics
 
 
 
+  Scenario: Disable Frame Rate Metrics
+    When I run the game in the "ConfigureRenderMetrics" state
+    And I wait for 1 span
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "BeforeStart"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes" is an array with 4 elements
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" boolean attribute "bugsnag.span.first_class" is true
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "custom"
+
+
+
 
 
 


### PR DESCRIPTION
## Goal

add frame rate metrics to custom first class spans and automatic navigation, network and app start spans.

## Changeset

Added FrameMetricsCollector that hooks into the unity update call. This is called once per frame and checks Time.unscaledDeltaTime to decide what category of frame has just happened.

Added check to remove metrics added to spans before start is called if rendering metrics are not enabled in config.

Added new config option to the config window.

## Testing

Added new E2E tests