### PR TITLE
improve scripting symbol addition and handle unity deprecations 

### DIFF
--- a/BugsnagPerformance/Assets/BugsnagPerformance/Editor/AddScriptingSymbol.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Editor/AddScriptingSymbol.cs
@@ -10,32 +10,32 @@ public class AddScriptingSymbol : MonoBehaviour
 
     private static BuildTargetGroup[] _supportedPlatforms = { BuildTargetGroup.Android, BuildTargetGroup.Standalone, BuildTargetGroup.iOS, BuildTargetGroup.WebGL };
 
-        static AddScriptingSymbol()
+    static AddScriptingSymbol()
+    {
+        foreach (var target in _supportedPlatforms)
         {
-            foreach (var target in _supportedPlatforms)
+            try
             {
-                try
-                {
-                    SetScriptingSymbol(target);
-                }
-                catch
-                {
-                    // Some users might not have a platform installed, in that case ignore the error
-                }
+                SetScriptingSymbol(target);
+            }
+            catch
+            {
+                // Some users might not have a platform installed, in that case ignore the error
             }
         }
+    }
 
-        static void SetScriptingSymbol(BuildTargetGroup buildTargetGroup)
+    static void SetScriptingSymbol(BuildTargetGroup buildTargetGroup)
+    {
+        var existingSymbols = BugsnagPlayerSettingsCompat.GetScriptingDefineSymbols(buildTargetGroup);
+        if (string.IsNullOrEmpty(existingSymbols))
         {
-            var existingSymbols = BugsnagPlayerSettingsCompat.GetScriptingDefineSymbols(buildTargetGroup);
-            if (string.IsNullOrEmpty(existingSymbols))
-            {
-                existingSymbols = DEFINE_SYMBOL;
-            }
-            else if (!existingSymbols.Contains(DEFINE_SYMBOL))
-            {
-                existingSymbols += ";" + DEFINE_SYMBOL;
-            }
-            BugsnagPlayerSettingsCompat.SetScriptingDefineSymbols(buildTargetGroup, existingSymbols);
+            existingSymbols = DEFINE_SYMBOL;
         }
+        else if (!existingSymbols.Contains(DEFINE_SYMBOL))
+        {
+            existingSymbols += ";" + DEFINE_SYMBOL;
+        }
+        BugsnagPlayerSettingsCompat.SetScriptingDefineSymbols(buildTargetGroup, existingSymbols);
+    }
 }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Editor/AddScriptingSymbol.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Editor/AddScriptingSymbol.cs
@@ -8,29 +8,34 @@ public class AddScriptingSymbol : MonoBehaviour
 
     private const string DEFINE_SYMBOL = "BUGSNAG_PERFORMANCE";
 
-    private static BuildTargetGroup[] _supportedPlatforms = { BuildTargetGroup.Android, BuildTargetGroup.Standalone, BuildTargetGroup.iOS, BuildTargetGroup.WebGL};
+    private static BuildTargetGroup[] _supportedPlatforms = { BuildTargetGroup.Android, BuildTargetGroup.Standalone, BuildTargetGroup.iOS, BuildTargetGroup.WebGL };
 
-    static AddScriptingSymbol()
-    {
-        foreach (var target in _supportedPlatforms)
+        static AddScriptingSymbol()
         {
-            try
+            foreach (var target in _supportedPlatforms)
             {
-                SetScriptingSymbol(target);
-            }
-            catch
-            {
-                // Some users might not have a platform installed, in that case ignore the error
+                try
+                {
+                    SetScriptingSymbol(target);
+                }
+                catch
+                {
+                    // Some users might not have a platform installed, in that case ignore the error
+                }
             }
         }
-    }
 
-    static void SetScriptingSymbol(BuildTargetGroup buildTargetGroup)
-    {
-        var existingSymbols = PlayerSettings.GetScriptingDefineSymbolsForGroup(buildTargetGroup);
-        if (!existingSymbols.Contains(DEFINE_SYMBOL))
+        static void SetScriptingSymbol(BuildTargetGroup buildTargetGroup)
         {
-            PlayerSettings.SetScriptingDefineSymbolsForGroup(buildTargetGroup,existingSymbols + ";" + DEFINE_SYMBOL);
+            var existingSymbols = BugsnagPlayerSettingsCompat.GetScriptingDefineSymbols(buildTargetGroup);
+            if (string.IsNullOrEmpty(existingSymbols))
+            {
+                existingSymbols = DEFINE_SYMBOL;
+            }
+            else if (!existingSymbols.Contains(DEFINE_SYMBOL))
+            {
+                existingSymbols += ";" + DEFINE_SYMBOL;
+            }
+            BugsnagPlayerSettingsCompat.SetScriptingDefineSymbols(buildTargetGroup, existingSymbols);
         }
-    }
 }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Editor/PlayerSettingsCompat.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Editor/PlayerSettingsCompat.cs
@@ -9,7 +9,7 @@ using UnityEditor.Build;
         public static ScriptingImplementation GetScriptingBackend(BuildTargetGroup buildTargetGroup)
         {
 #if UNITY_2021_2_OR_NEWER
-        return PlayerSettings.GetScriptingBackend(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup));
+            return PlayerSettings.GetScriptingBackend(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup));
 #else
             return PlayerSettings.GetScriptingBackend(buildTargetGroup);
 #endif
@@ -18,9 +18,9 @@ using UnityEditor.Build;
         public static string GetApplicationIdentifier(BuildTargetGroup buildTargetGroup)
         {
 #if UNITY_2021_2_OR_NEWER
-                return PlayerSettings.GetApplicationIdentifier(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup));
+            return PlayerSettings.GetApplicationIdentifier(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup));
 #else
-                return PlayerSettings.GetApplicationIdentifier(buildTargetGroup);
+            return PlayerSettings.GetApplicationIdentifier(buildTargetGroup);
 #endif
         }
 
@@ -28,7 +28,7 @@ using UnityEditor.Build;
         public static string GetScriptingDefineSymbols(BuildTargetGroup buildTargetGroup)
         {
 #if UNITY_2021_2_OR_NEWER
-        return PlayerSettings.GetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup));
+            return PlayerSettings.GetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup));
 #else
             return PlayerSettings.GetScriptingDefineSymbolsForGroup(buildTargetGroup);
 #endif
@@ -38,7 +38,7 @@ using UnityEditor.Build;
         public static void SetScriptingDefineSymbols(BuildTargetGroup buildTargetGroup, string defineSymbols)
         {
 #if UNITY_2021_2_OR_NEWER
-        PlayerSettings.SetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup), defineSymbols);
+            PlayerSettings.SetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup), defineSymbols);
 #else
             PlayerSettings.SetScriptingDefineSymbolsForGroup(buildTargetGroup, defineSymbols);
 #endif

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Editor/PlayerSettingsCompat.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Editor/PlayerSettingsCompat.cs
@@ -1,0 +1,46 @@
+using UnityEditor;
+#if UNITY_2021_2_OR_NEWER
+using UnityEditor.Build;
+#endif
+
+    internal static class BugsnagPlayerSettingsCompat
+    {
+        // Get Scripting Backend
+        public static ScriptingImplementation GetScriptingBackend(BuildTargetGroup buildTargetGroup)
+        {
+#if UNITY_2021_2_OR_NEWER
+        return PlayerSettings.GetScriptingBackend(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup));
+#else
+            return PlayerSettings.GetScriptingBackend(buildTargetGroup);
+#endif
+        }
+
+        public static string GetApplicationIdentifier(BuildTargetGroup buildTargetGroup)
+        {
+#if UNITY_2021_2_OR_NEWER
+                return PlayerSettings.GetApplicationIdentifier(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup));
+#else
+                return PlayerSettings.GetApplicationIdentifier(buildTargetGroup);
+#endif
+        }
+
+        // Get Scripting Define Symbols
+        public static string GetScriptingDefineSymbols(BuildTargetGroup buildTargetGroup)
+        {
+#if UNITY_2021_2_OR_NEWER
+        return PlayerSettings.GetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup));
+#else
+            return PlayerSettings.GetScriptingDefineSymbolsForGroup(buildTargetGroup);
+#endif
+        }
+
+        // Set Scripting Define Symbols
+        public static void SetScriptingDefineSymbols(BuildTargetGroup buildTargetGroup, string defineSymbols)
+        {
+#if UNITY_2021_2_OR_NEWER
+        PlayerSettings.SetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup), defineSymbols);
+#else
+            PlayerSettings.SetScriptingDefineSymbolsForGroup(buildTargetGroup, defineSymbols);
+#endif
+        }
+    }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Editor/PlayerSettingsCompat.cs.meta
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Editor/PlayerSettingsCompat.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 32c8f9b9cea7c4256b03e4e0bd01e6c8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.8.1 TBD
+##  TBD
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.8.1 TBD
+
+### Bug Fixes
+
+- Fix issue where scripting symbols were not always correctly set in batch mode. [#164](https://github.com/bugsnag/bugsnag-unity-performance/pull/164)
+
 ## v1.8.0 (2025-02-05)
 
 ### Additions


### PR DESCRIPTION
## Goal

Add a PlayerSettingsCompat class to handle changes in the Unity PlayerSettings API.
Fix a bug where when running in batch mode could remove all scripting symbols.

## Testing

Covered by existing E2E tests. Will also have extra coverage once released as this fix will allow for the performance sdk to be present in the notifier fixture.