### PR TITLE
add basic fps rendering metrics

### DIFF
--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/FrameMetricsCollector.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/FrameMetricsCollector.cs
@@ -251,7 +251,7 @@ namespace BugsnagUnityPerformance
             foreach (var pair in _instrumentedSpans)
             {
                 pair.Value.UpdateFrameRate(frameRate);
-            }            
+            }   
         }
 
         private FrameMetricsSnapshot TakeSnapshot()

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/SpanFactory.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/SpanFactory.cs
@@ -113,13 +113,16 @@ namespace BugsnagUnityPerformance
 
             var newSpan = new Span(name, kind, spanId, 
             traceId, parentSpanId, spanOptions.StartTime, 
-            spanOptions.IsFirstClass, _onSpanEnd, _maxCustomAttributes, 
-            spanOptions.InstrumentRendering.Value ? _frameMetricsCollector.TakeSnapshot() : null);
+            spanOptions.IsFirstClass, _onSpanEnd, _maxCustomAttributes);
             if (spanOptions.MakeCurrentContext)
             {
                 AddToContextStack(newSpan);
             }
             newSpan.SetAttributeInternal("net.host.connection.type", _currentConnectionType);
+            if(spanOptions.InstrumentRendering != null && spanOptions.InstrumentRendering.Value)
+            {
+                _frameMetricsCollector.OnSpanStart(newSpan);
+            }
             return newSpan;
         }
 

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Tracer.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Tracer.cs
@@ -109,7 +109,7 @@ namespace BugsnagUnityPerformance
 
         private void ApplyFrameRateMetrics(Span span)
         {
-            span.CalculateFrameRateMetrics(_frameMetricsCollector.TakeSnapshot());
+            _frameMetricsCollector.OnSpanEnd(span);
         }
 
         public void RunOnEndCallbacks(Span span)

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Models/ResourceModel.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Models/ResourceModel.cs
@@ -26,7 +26,9 @@ namespace BugsnagUnityPerformance
                 new AttributeModel("service.version", string.IsNullOrEmpty(config.AppVersion) ? Application.version : config.AppVersion),
                 new AttributeModel("service.name", GetServiceName(config)),
                 new AttributeModel("bugsnag.app.platform", GetPlatform()),
-                new AttributeModel("bugsnag.runtime_versions.unity", Application.unityVersion)
+                new AttributeModel("bugsnag.runtime_versions.unity", Application.unityVersion),
+                new AttributeModel("device.screen_resolution.width", Screen.width),
+                new AttributeModel("device.screen_resolution.height", Screen.height)
             };
             AddNonNullAttribute(GetNativeVersionInfo(config));
             AddNonNullAttribute(GetManufacturer());

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/Span.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/Span.cs
@@ -234,6 +234,10 @@ namespace BugsnagUnityPerformance
         {
             var beginningMetrics = metrics.BeginningMetrics;
             var endMetrics = metrics.EndingMetrics;
+            if (beginningMetrics == null || endMetrics == null)
+            {
+                return;
+            }
             var numFrozenFrames = endMetrics.FrozenFrames - beginningMetrics.FrozenFrames;
             var frozenFrameDurations = endMetrics.FrozenFrameBuffer.GetLastFrames(numFrozenFrames);
             for (int i = 0; i < endMetrics.FrozenFrames; i++)

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/Span.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/Span.cs
@@ -232,11 +232,11 @@ namespace BugsnagUnityPerformance
 
         internal void CalculateFrameRateMetrics(SpanRenderingMetrics metrics)
         {
-            var beginning = metrics.BeginningMetrics;
-            var end = metrics.EndingMetrics;
-            var numFrozenFrames = end.FrozenFrames - beginning.FrozenFrames;
-            var frozenFrameDurations = end.FrozenFrameBuffer.GetLastFrames(numFrozenFrames);
-            for (int i = 0; i < end.FrozenFrames; i++)
+            var beginningMetrics = metrics.BeginningMetrics;
+            var endMetrics = metrics.EndingMetrics;
+            var numFrozenFrames = endMetrics.FrozenFrames - beginningMetrics.FrozenFrames;
+            var frozenFrameDurations = endMetrics.FrozenFrameBuffer.GetLastFrames(numFrozenFrames);
+            for (int i = 0; i < endMetrics.FrozenFrames; i++)
             {
                 if (i >= frozenFrameDurations.Count)
                 {
@@ -256,15 +256,17 @@ namespace BugsnagUnityPerformance
                 span.End(frameTimes.EndTime);
             }
 
-            var totalFrames = end.TotalFrames - beginning.TotalFrames;
-            var sumFrametime = end.FrameTimeSum - beginning.FrameTimeSum; 
+            var totalFrames = endMetrics.TotalFrames - beginningMetrics.TotalFrames;
+            var sumFrametime = endMetrics.FrameTimeSum - beginningMetrics.FrameTimeSum; 
             var averageFps = (int)(1.0f / (sumFrametime / totalFrames));
 
             SetAttributeInternal(FPS_AVERAGE_KEY, averageFps);
             SetAttributeInternal(FROZEN_FRAMES_KEY, numFrozenFrames);
-            SetAttributeInternal(SLOW_FRAMES_KEY, end.SlowFrames - beginning.SlowFrames);
+            SetAttributeInternal(SLOW_FRAMES_KEY, endMetrics.SlowFrames - beginningMetrics.SlowFrames);
             SetAttributeInternal(TOTAL_FRAMES_KEY, totalFrames);
-            UnityEngine.Debug.Log("Should be applied");
+            SetAttributeInternal(FPS_MAX_KEY, metrics.MaxFrameRate);
+            SetAttributeInternal(FPS_MIN_KEY, metrics.MinFrameRate);
+            SetAttributeInternal(FPS_TARGET_KEY, beginningMetrics.TargetFrameRate);
         }
 
         internal void RemoveFrameRateMetrics()
@@ -272,6 +274,10 @@ namespace BugsnagUnityPerformance
             _attributes.Remove(FROZEN_FRAMES_KEY);
             _attributes.Remove(SLOW_FRAMES_KEY);
             _attributes.Remove(TOTAL_FRAMES_KEY);
+            _attributes.Remove(FPS_MAX_KEY);
+            _attributes.Remove(FPS_MIN_KEY);
+            _attributes.Remove(FPS_AVERAGE_KEY);
+            _attributes.Remove(FPS_TARGET_KEY);
         }
     }
 }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/Span.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/Span.cs
@@ -261,13 +261,18 @@ namespace BugsnagUnityPerformance
             }
 
             var totalFrames = endMetrics.TotalFrames - beginningMetrics.TotalFrames;
+            SetAttributeInternal(TOTAL_FRAMES_KEY, totalFrames);
+            
+            if (totalFrames == 0)
+            {
+                return;
+            }
             var sumFrametime = endMetrics.FrameTimeSum - beginningMetrics.FrameTimeSum; 
             var averageFps = (int)(1.0f / (sumFrametime / totalFrames));
 
             SetAttributeInternal(FPS_AVERAGE_KEY, averageFps);
             SetAttributeInternal(FROZEN_FRAMES_KEY, numFrozenFrames);
             SetAttributeInternal(SLOW_FRAMES_KEY, endMetrics.SlowFrames - beginningMetrics.SlowFrames);
-            SetAttributeInternal(TOTAL_FRAMES_KEY, totalFrames);
             SetAttributeInternal(FPS_MAX_KEY, metrics.MaxFrameRate);
             SetAttributeInternal(FPS_MIN_KEY, metrics.MinFrameRate);
             SetAttributeInternal(FPS_TARGET_KEY, beginningMetrics.TargetFrameRate);

--- a/BugsnagPerformance/Assets/UnitTests/ConfigurationTests.cs
+++ b/BugsnagPerformance/Assets/UnitTests/ConfigurationTests.cs
@@ -82,8 +82,7 @@ namespace Tests
                 CustomStartTime,
                 true,
                 OnSpanEnd,
-                128,
-                null);
+                128);
             span.End(CustomEndTime);
             Assert.AreEqual(span.StartTime, CustomStartTime);
             Assert.AreEqual(span.EndTime, CustomEndTime);

--- a/BugsnagPerformance/Assets/UnitTests/SamplerTests.cs
+++ b/BugsnagPerformance/Assets/UnitTests/SamplerTests.cs
@@ -52,8 +52,7 @@ namespace Tests
                 DateTimeOffset.Now,
                 true,
                 OnSpanEnd,
-                128,
-                null);
+                128);
 
             Assert.AreEqual(1.0, sampler.Probability);
             Assert.IsTrue(sampler.Sampled(span));
@@ -92,8 +91,7 @@ namespace Tests
                 DateTimeOffset.Now,
                 true,
                 OnSpanEnd,
-                128,
-                null);
+                128);
 
             Assert.IsTrue(sampler.Sampled(span));
         }
@@ -113,8 +111,7 @@ namespace Tests
                 DateTimeOffset.Now,
                 true,
                 OnSpanEnd,
-                128,
-                null);
+                128);
 
             Assert.IsFalse(sampler.Sampled(span));
         }
@@ -134,8 +131,7 @@ namespace Tests
                 DateTimeOffset.Now,
                 true,
                 OnSpanEnd,
-                128,
-                null);
+                128);
 
             Assert.IsFalse(sampler.Sampled(span));
 
@@ -147,8 +143,7 @@ namespace Tests
                 DateTimeOffset.Now,
                 true,
                 OnSpanEnd,
-                128,
-                null);
+                128);
             Assert.IsTrue(sampler.Sampled(span));
 
         }
@@ -168,8 +163,7 @@ namespace Tests
                 DateTimeOffset.Now,
                 true,
                 OnSpanEnd,
-                128,
-                null);
+                128);
 
             Assert.IsTrue(sampler.Sampled(span));
 
@@ -181,8 +175,7 @@ namespace Tests
                 DateTimeOffset.Now,
                 true,
                 OnSpanEnd,
-                128,
-                null);
+                128);
             Assert.IsTrue(sampler.Sampled(span));
 
             span = new Span("test",
@@ -193,8 +186,7 @@ namespace Tests
                 DateTimeOffset.Now,
                 true,
                 OnSpanEnd,
-                128,
-                null);
+                128);
             Assert.IsFalse(sampler.Sampled(span));
 
         }

--- a/BugsnagPerformance/Assets/UnitTests/TracePayloadTests.cs
+++ b/BugsnagPerformance/Assets/UnitTests/TracePayloadTests.cs
@@ -126,8 +126,7 @@ namespace Tests
                             DateTimeOffset.Now,
                             true,
                             OnSpanEnd,
-                            128,
-                null);
+                            128);
             span.UpdateSamplingProbability(probability);
             return span;
         }

--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -30,6 +30,10 @@ Feature: Manual creation of spans
     * the trace payload field "resourceSpans.0.resource" string attribute "device.id" exists
     * the trace payload field "resourceSpans.0.resource" string attribute "device.model.identifier" exists
     * the trace payload field "resourceSpans.0.resource" string attribute "service.version" equals "1.0"
+    * the trace payload field "resourceSpans.0.resource" integer attribute "device.screen_resolution.width" is greater than 100
+    * the trace payload field "resourceSpans.0.resource" integer attribute "device.screen_resolution.height" is greater than 100
+
+
     * the trace payload field "resourceSpans.0.resource" string attribute "service.name" is one of:
       | com.bugsnag.fixtures.unity.performance.android |
       | com.bugsnag.fixtures.unity.performance.ios |

--- a/features/rendering_metrics.feature
+++ b/features/rendering_metrics.feature
@@ -15,10 +15,13 @@ Feature: Rendering Metrics
     * the span named "FrozenFrame" starts and ends before the span named "SlowFrames" ends and lasts at least 1 second
 
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.name" equals "SlowFrames"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.attributes" is an array with 7 elements
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1.attributes" is an array with 11 elements
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" integer attribute "bugsnag.rendering.frozen_frames" equals 1
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" integer attribute "bugsnag.rendering.slow_frames" is greater than 9
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" integer attribute "bugsnag.rendering.total_frames" equals 100
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" integer attribute "bugsnag.rendering.fps_average" is greater than 0
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" integer attribute "bugsnag.rendering.fps_maximum" is greater than 0
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.1" integer attribute "bugsnag.rendering.fps_minimum" is greater than -1
 
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.2.name" equals "NoFrames"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.2.attributes" is an array with 4 elements
@@ -29,8 +32,6 @@ Feature: Rendering Metrics
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.3.attributes" is an array with 4 elements
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.3" boolean attribute "bugsnag.span.first_class" is true
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.3" string attribute "bugsnag.span.category" equals "custom"
-
-
 
   Scenario: Disable Frame Rate Metrics
     When I run the game in the "ConfigureRenderMetrics" state


### PR DESCRIPTION
## Goal

add the following new span attributes:

```
bugsnag.rendering.fps_target
bugsnag.rendering.fps_average
bugsnag.rendering.fps_minimum
bugsnag.rendering.fps_maximum
```

add the following new resource attributes:

```
device.screen_resolution.width
device.screen_resolution.height
```

## Changeset

- register eligible spans in the FrameMetricsCollector on collection.
- apply collected metrics on span end
- add screen res attribute in the Resource Model class

## Testing

Updated existing tests with the new attributes