### PR TITLE
implement span metrics object

### DIFF
--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/AppStartHandler.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/AppStartHandler.cs
@@ -6,6 +6,19 @@ namespace BugsnagUnityPerformance
 {
     public class AppStartHandler : IPhasedStartup
     {
+        private const string UNITY_RUNTIME_SPAN_NAME = "[AppStart/UnityRuntime]";
+        private const string APP_START_CATEGORY = "app_start";
+
+        private const string LOAD_ASSEMBLIES_SPAN_NAME = "[AppStartPhase/LoadAssemblies]";
+        private const string APP_START_PHASE_CATEGORY = "app_start_phase";
+        private const string BUGSNAG_PHASE_KEY = "bugsnag.phase";
+        private const string LOAD_ASSEMBLIES_PHASE = "LoadAssemblies";
+
+        private const string SPLASH_SCREEN_SPAN_NAME = "[AppStartPhase/SplashScreen]";
+        private const string SPLASH_SCREEN_PHASE = "SplashScreen";
+
+        private const string LOAD_FIRST_SCENE_SPAN_NAME = "[AppStartPhase/LoadFirstScene]";
+        private const string LOAD_FIRST_SCENE_PHASE = "LoadFirstScene";
 
         private static Span _rootSpan;
         private static Span _loadAssembliesSpan;
@@ -82,14 +95,14 @@ namespace BugsnagUnityPerformance
 
         private static Span CreateAppStartSpan(string name, string category)
         {
-            return _spanFactory.CreateAutoAppStartSpan(name, category);
+            return _spanFactory.CreateAutoAppStartSpan(name, category, category.Equals(APP_START_CATEGORY));
         }
 
         internal void SubsystemRegistration()
         {
-            _rootSpan = CreateAppStartSpan("[AppStart/UnityRuntime]", "app_start");
-            _loadAssembliesSpan = CreateAppStartSpan("[AppStartPhase/LoadAssemblies]", "app_start_phase");
-            _loadAssembliesSpan.SetAttributeInternal("bugsnag.phase", "LoadAssemblies");
+            _rootSpan = CreateAppStartSpan(UNITY_RUNTIME_SPAN_NAME, APP_START_CATEGORY);
+            _loadAssembliesSpan = CreateAppStartSpan(LOAD_ASSEMBLIES_SPAN_NAME, APP_START_PHASE_CATEGORY);
+            _loadAssembliesSpan.SetAttributeInternal(BUGSNAG_PHASE_KEY, LOAD_ASSEMBLIES_PHASE);
         }
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterAssembliesLoaded)]
@@ -101,15 +114,15 @@ namespace BugsnagUnityPerformance
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSplashScreen)]
         private static void BeforeSplashScreen()
         {
-            _splashScreenSpan = CreateAppStartSpan("[AppStartPhase/SplashScreen]", "app_start_phase");
-            _splashScreenSpan.SetAttributeInternal("bugsnag.phase", "SplashScreen");
+            _splashScreenSpan = CreateAppStartSpan(SPLASH_SCREEN_SPAN_NAME, APP_START_PHASE_CATEGORY);
+            _splashScreenSpan.SetAttributeInternal(BUGSNAG_PHASE_KEY, SPLASH_SCREEN_PHASE);
         }
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         private static void BeforeSceneLoad()
         {
-            _firstSceneSpan = CreateAppStartSpan("[AppStartPhase/LoadFirstScene]", "app_start_phase");
-            _firstSceneSpan.SetAttributeInternal("bugsnag.phase", "LoadFirstScene");
+            _firstSceneSpan = CreateAppStartSpan(LOAD_FIRST_SCENE_SPAN_NAME, APP_START_PHASE_CATEGORY);
+            _firstSceneSpan.SetAttributeInternal(BUGSNAG_PHASE_KEY, LOAD_FIRST_SCENE_PHASE);
         }
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
@@ -121,6 +134,5 @@ namespace BugsnagUnityPerformance
             // Save the time so that we can use it later if full auto instrumentation is set
             _defaultAppStartEndTime = DateTimeOffset.UtcNow;
         }
-
     }
 }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/SpanOptions.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/SpanOptions.cs
@@ -1,12 +1,19 @@
 ﻿using System;
 namespace BugsnagUnityPerformance
 {
+    public class SpanMetrics
+    {
+        public bool Rendering = false;
+        public bool CPU = false;
+        public bool Memory = false;
+    }
+
     public class SpanOptions
     {
         public DateTimeOffset StartTime = DateTimeOffset.UtcNow;
         public ISpanContext ParentContext = null;
         public bool MakeCurrentContext = true;
         public bool? IsFirstClass = null;
-        public bool? InstrumentRendering = null;
+        public SpanMetrics SpanMetrics = null;
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Deprecations
+
+- SpanOptions.InstrumentRendering has been removed in favor of the new SpanOptions.SpanMetrics option. [#172](https://github.com/bugsnag/bugsnag-unity-performance/pull/172)
+
 ## v1.8.1 (2025-03-27)
 
 ### Bug Fixes

--- a/features/app_start_spans.feature
+++ b/features/app_start_spans.feature
@@ -17,14 +17,15 @@ Feature: App Start
     * the span named "[AppStart/UnityRuntime]" exists
 
     * the span named "[AppStart/UnityRuntime]" has no parent
-
     * the span named "[AppStart/UnityRuntime]" is the parent of the span named "[AppStartPhase/LoadAssemblies]"
-
     * the span named "[AppStart/UnityRuntime]" is the parent of the span named "[AppStartPhase/SplashScreen]"
-
     * the span named "[AppStartPhase/SplashScreen]" is the parent of the span named "[AppStartPhase/LoadFirstScene]"
-
     * the span named "[AppStart/UnityRuntime]" has a maximum duration of 3000000000
+
+    * the span named "[AppStart/UnityRuntime]" is first class
+    * the span named "[AppStartPhase/LoadFirstScene]" is not first class
+    * the span named "[AppStartPhase/SplashScreen]" is not first class
+    * the span named "[AppStartPhase/LoadAssemblies]" is not first class
 
 Scenario: App Start Start Only
     When I run the game in the "AppStartStartOnly" state

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Metrics/RenderMetrics.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Metrics/RenderMetrics.cs
@@ -47,7 +47,7 @@ public class RenderMetrics : Scenario
             _testInitialised = true;
              _slowFrameSpan = BugsnagPerformance.StartSpan("SlowFrames");
             _noFramesSpan = BugsnagPerformance.StartSpan("NoFrames", new SpanOptions { IsFirstClass = false });
-            _disableInSpanOptionsSpan = BugsnagPerformance.StartSpan("DisableInSpanOptions", new SpanOptions { InstrumentRendering = false });
+            _disableInSpanOptionsSpan = BugsnagPerformance.StartSpan("DisableInSpanOptions", new SpanOptions { SpanMetrics = new SpanMetrics { Rendering = false } });
         }
         if (_slowFramesDone < NUM_SLOW_FRAMES_TO_DO)
         {

--- a/features/network_spans.feature
+++ b/features/network_spans.feature
@@ -12,6 +12,8 @@ Feature: Network Spans
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "HTTP/GET"
 
+    * the span named "HTTP/GET" is first class
+
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "network"
 
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "net.host.connection.type" equals "wifi"
@@ -148,6 +150,8 @@ Feature: Network Spans
     * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "HTTP/PATCH"
+
+    * the span named "HTTP/PATCH" is first class
 
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "network"
 

--- a/features/scene_load_spans.feature
+++ b/features/scene_load_spans.feature
@@ -13,6 +13,8 @@ Feature: Scene Load Spans
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[ViewLoad/UnityScene]Scene1"
 
+    * the span named "[ViewLoad/UnityScene]Scene1" is first class
+
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "view_load"
 
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.view.type" equals "UnityScene"
@@ -71,6 +73,7 @@ Feature: Scene Load Spans
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
 
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "[ViewLoad/UnityScene]ManualSceneSpan"
+    * the span named "[ViewLoad/UnityScene]ManualSceneSpan" is first class
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "view_load"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.view.type" equals "UnityScene"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.view.name" equals "ManualSceneSpan"

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -191,28 +191,24 @@ Then('the span named {string} starts and ends before the span named {string} end
   Maze.check.true(duration_nanos >= min_duration_nanos, "Expected span '#{span1_name}' to last at least 1 second, but it lasted #{duration_nanos} nanoseconds")
 end
 
-Then('the span named {string} is first class') do |span_name|
+def check_span_first_class(span_name, expected)
   spans = spans_from_request_list(Maze::Server.list_for("traces"))
   span = spans.find { |s| s['name'].eql?(span_name) }
   raise Test::Unit::AssertionFailedError.new "No span found with the name #{span_name}" if span.nil?
 
-  # Find the 'bugsnag.span.first_class' attribute
   first_class_attr = span['attributes'].find { |attr| attr['key'] == 'bugsnag.span.first_class' }
   raise Test::Unit::AssertionFailedError.new "No attribute 'bugsnag.span.first_class' found for #{span_name}" if first_class_attr.nil?
 
-  # Verify that boolValue is true
-  Maze.check.true(first_class_attr['value']['boolValue'] == true, "Expected '#{span_name}' to be first class")
+  Maze.check.true(
+    first_class_attr['value']['boolValue'] == expected,
+    "Expected '#{span_name}' to be first class: #{expected}, but it was not."
+  )
+end
+
+Then('the span named {string} is first class') do |span_name|
+  check_span_first_class(span_name, true)
 end
 
 Then('the span named {string} is not first class') do |span_name|
-  spans = spans_from_request_list(Maze::Server.list_for("traces"))
-  span = spans.find { |s| s['name'].eql?(span_name) }
-  raise Test::Unit::AssertionFailedError.new "No span found with the name #{span_name}" if span.nil?
-
-  # Find the 'bugsnag.span.first_class' attribute
-  first_class_attr = span['attributes'].find { |attr| attr['key'] == 'bugsnag.span.first_class' }
-  raise Test::Unit::AssertionFailedError.new "No attribute 'bugsnag.span.first_class' found for #{span_name}" if first_class_attr.nil?
-
-  # Verify that boolValue is false
-  Maze.check.true(first_class_attr['value']['boolValue'] == false, "Expected '#{span_name}' not to be first class")
+  check_span_first_class(span_name, false)
 end

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -190,3 +190,29 @@ Then('the span named {string} starts and ends before the span named {string} end
   Maze.check.true(span1_end_time < span2_end_time, "Expected span '#{span1_name}' to end before span '#{span2_name}' ends")
   Maze.check.true(duration_nanos >= min_duration_nanos, "Expected span '#{span1_name}' to last at least 1 second, but it lasted #{duration_nanos} nanoseconds")
 end
+
+Then('the span named {string} is first class') do |span_name|
+  spans = spans_from_request_list(Maze::Server.list_for("traces"))
+  span = spans.find { |s| s['name'].eql?(span_name) }
+  raise Test::Unit::AssertionFailedError.new "No span found with the name #{span_name}" if span.nil?
+
+  # Find the 'bugsnag.span.first_class' attribute
+  first_class_attr = span['attributes'].find { |attr| attr['key'] == 'bugsnag.span.first_class' }
+  raise Test::Unit::AssertionFailedError.new "No attribute 'bugsnag.span.first_class' found for #{span_name}" if first_class_attr.nil?
+
+  # Verify that boolValue is true
+  Maze.check.true(first_class_attr['value']['boolValue'] == true, "Expected '#{span_name}' to be first class")
+end
+
+Then('the span named {string} is not first class') do |span_name|
+  spans = spans_from_request_list(Maze::Server.list_for("traces"))
+  span = spans.find { |s| s['name'].eql?(span_name) }
+  raise Test::Unit::AssertionFailedError.new "No span found with the name #{span_name}" if span.nil?
+
+  # Find the 'bugsnag.span.first_class' attribute
+  first_class_attr = span['attributes'].find { |attr| attr['key'] == 'bugsnag.span.first_class' }
+  raise Test::Unit::AssertionFailedError.new "No attribute 'bugsnag.span.first_class' found for #{span_name}" if first_class_attr.nil?
+
+  # Verify that boolValue is false
+  Maze.check.true(first_class_attr['value']['boolValue'] == false, "Expected '#{span_name}' not to be first class")
+end


### PR DESCRIPTION
## Goal

This PR is the ground work required before adding the csharp layer of CPU/Memory metrics.

The goal is to implement span metrics object and remove `SpanOptions.InstrumentRendering`

## Changeset

- remove `SpanOptions.InstrumentRendering`
- implement `SpanMetrics` object.
- Refactor App starts to use const keys and set the correct First Class attribute.
- Refactor `SpanFactory` so that the reading and setting of IsFirstClass is easier to understand.

## Testing

- Updated existing tests to check for IsFirst class when relevant.