### PR TITLE
csharp CPU and Memory metrics layer

### DIFF
--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/AppStartHandler.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/AppStartHandler.cs
@@ -68,7 +68,7 @@ namespace BugsnagUnityPerformance
         {
             if (_config.AutoInstrumentAppStart == AutoInstrumentAppStartSetting.FULL)
             {
-                MainThreadDispatchBehaviour.Instance().Enqueue(CheckForAppStartCompletion());
+                MainThreadDispatchBehaviour.Enqueue(CheckForAppStartCompletion());
             }
         }
 

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Delivery.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Delivery.cs
@@ -66,7 +66,7 @@ namespace BugsnagUnityPerformance
         public void Deliver(List<Span> batch)
         {
             var payload = new TracePayload(_resourceModel, batch, _config.IsFixedSamplingProbability, _config.AttributeArrayLengthLimit, _config.AttributeStringValueLimit);
-            MainThreadDispatchBehaviour.Instance().Enqueue(PushToServer(payload, OnTraceDeliveryCompleted));
+            MainThreadDispatchBehaviour.Enqueue(PushToServer(payload, OnTraceDeliveryCompleted));
         }
 
         private void OnTraceDeliveryCompleted(TracePayload payload, UnityWebRequest req, double newProbability)
@@ -96,7 +96,7 @@ namespace BugsnagUnityPerformance
                 onResponse = OnPValueRequestCompleted;
             }
             var payload = TracePayload.GetTracePayloadForPValueRequest(_resourceModel);
-            MainThreadDispatchBehaviour.Instance().Enqueue(PushToServer(payload, onResponse));
+            MainThreadDispatchBehaviour.Enqueue(PushToServer(payload, onResponse));
         }
 
         private void OnPValueRequestCompleted(TracePayload payload, UnityWebRequest req, double newProbability)
@@ -185,7 +185,7 @@ namespace BugsnagUnityPerformance
                 return;
             }
             _flushingCache = true;
-            MainThreadDispatchBehaviour.Instance().Enqueue(DoFlushCache());
+            MainThreadDispatchBehaviour.Enqueue(DoFlushCache());
         }
 
         private IEnumerator DoFlushCache()

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/FrameMetricsCollector.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/FrameMetricsCollector.cs
@@ -250,6 +250,14 @@ namespace BugsnagUnityPerformance
             int frameRate = (int)(1.0f / frameTime);
             foreach (var pair in _instrumentedSpans)
             {
+                if (!pair.Key.TryGetTarget(out var spanRef))
+                {
+                    continue; // Span no longer exists
+                }
+                if(spanRef.Ended)
+                {
+                    continue; // Span has ended
+                }
                 pair.Value.UpdateFrameRate(frameRate);
             }   
         }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/FrameMetricsCollector.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/FrameMetricsCollector.cs
@@ -144,7 +144,6 @@ namespace BugsnagUnityPerformance
         public void OnSpanEnd(Span span)
         {
             SpanRenderingMetrics spanMetrics = GetSpanMetrics(span);
-
             if (spanMetrics == null)
             {
                 return;
@@ -250,14 +249,6 @@ namespace BugsnagUnityPerformance
             int frameRate = (int)(1.0f / frameTime);
             foreach (var pair in _instrumentedSpans)
             {
-                if (!pair.Key.TryGetTarget(out var spanRef))
-                {
-                    continue; // Span no longer exists
-                }
-                if(spanRef.Ended)
-                {
-                    continue; // Span has ended
-                }
                 pair.Value.UpdateFrameRate(frameRate);
             }   
         }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/MainThreadDispatchBehaviour.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/MainThreadDispatchBehaviour.cs
@@ -1,52 +1,50 @@
-﻿/*
-Copyright 2015 Pim de Witte All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections;
 using UnityEngine;
+using UnityEngine.LowLevel;
 
-/// Author: Pim de Witte (pimdewitte.com) and contributors
-/// <summary>
-/// A thread-safe class which holds a queue with actions to execute on the next Update() method. It can be used to make calls to the main thread for
-/// things such as UI Manipulation in Unity. It was developed for use in combination with the Firebase Unity plugin, which uses separate threads for event handling
-/// </summary>
 namespace BugsnagUnityPerformance
 {
-    public class MainThreadDispatchBehaviour : MonoBehaviour
+    public class BugsnagPerformanceCoroutineRunner : MonoBehaviour
     {
+        private static BugsnagPerformanceCoroutineRunner _instance;
 
-        private static MainThreadDispatchBehaviour _instance;
+        public static BugsnagPerformanceCoroutineRunner Instance
+        {
+            get
+            {
+                if (_instance == null)
+                {
+                    var runnerObject = new GameObject("BugsnagPerformanceCoroutineRunner");
+                    _instance = runnerObject.AddComponent<BugsnagPerformanceCoroutineRunner>();
+                    DontDestroyOnLoad(runnerObject);
+                }
+                return _instance;
+            }
+        }
+    }
+    public class MainThreadDispatchBehaviour
+    {
 
         private static readonly Queue<Action> _executionQueue = new Queue<Action>();
 
-
-        public static MainThreadDispatchBehaviour Instance()
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+        private static void InitializeLoop()
         {
-            if (_instance == null)
+            var playerLoop = PlayerLoop.GetCurrentPlayerLoop();
+            var newSystem = new PlayerLoopSystem
             {
-#if BUGSNAG_DEBUG
-                Logger.I("MainThreadDispatchBehaviour created");
-#endif
-                _instance = new GameObject("Bugsnag performance main thread dispatcher").AddComponent<MainThreadDispatchBehaviour>();
-            }
-            return _instance;
+                updateDelegate = OnUpdate
+            };
+
+            var systems = new List<PlayerLoopSystem>(playerLoop.subSystemList);
+            systems.Insert(0, newSystem);
+            playerLoop.subSystemList = systems.ToArray();
+            PlayerLoop.SetPlayerLoop(playerLoop);
         }
 
-        public void Update()
+        private static void OnUpdate()
         {
             lock (_executionQueue)
             {
@@ -57,58 +55,31 @@ namespace BugsnagUnityPerformance
             }
         }
 
-        /// <summary>
-        /// Locks the queue and adds the IEnumerator to the queue
-        /// </summary>
-        /// <param name="action">IEnumerator function that will be executed from the main thread.</param>
-        public void Enqueue(IEnumerator action)
+        public static void Enqueue(IEnumerator action)
         {
             lock (_executionQueue)
             {
                 _executionQueue.Enqueue(() =>
                 {
-                    StartCoroutine(action);
+                    BugsnagPerformanceCoroutineRunner.Instance.StartCoroutine(action);
                 });
             }
         }
 
-        public void LogWarning(string msg)
+        public static void Enqueue(Action action)
+        {
+            lock (_executionQueue)
+            {
+                _executionQueue.Enqueue(action);
+            }
+        }
+
+        public static void LogWarning(string msg)
         {
             Enqueue(() =>
             {
                 Debug.LogWarning(msg);
             });
         }
-
-        /// <summary>
-        /// Locks the queue and adds the Action to the queue
-        /// </summary>
-        /// <param name="action">function that will be executed from the main thread.</param>
-        public void Enqueue(Action action)
-        {
-            Enqueue(ActionWrapper(action));
-        }
-        IEnumerator ActionWrapper(Action a)
-        {
-            a();
-            yield return null;
-        }
-
-        public void EnqueueWithDelayCoroutine(Action action, float delay)
-        {
-            StartCoroutine(DelayAction(action, delay));
-        }
-
-        private IEnumerator DelayAction(Action action, float delay)
-        {
-            yield return new WaitForSeconds(delay);
-            action.Invoke();
-        }
-
-        private void Awake()
-        {
-            DontDestroyOnLoad(gameObject);
-        }
-
     }
 }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/PValueUpdater.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/PValueUpdater.cs
@@ -28,7 +28,7 @@ namespace BugsnagUnityPerformance
 
         public void Start()
         {
-            MainThreadDispatchBehaviour.Instance().Enqueue(CheckPValue());
+            MainThreadDispatchBehaviour.Enqueue(CheckPValue());
         }
         
         private IEnumerator CheckPValue()

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/PersistentState.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/PersistentState.cs
@@ -94,7 +94,7 @@ namespace BugsnagUnityPerformance
             }
             catch (Exception e)
             {
-                MainThreadDispatchBehaviour.Instance().LogWarning("Failed to save persistent state: " + e);
+                MainThreadDispatchBehaviour.LogWarning("Failed to save persistent state: " + e);
             }
             finally
             {

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/SpanFactory.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/SpanFactory.cs
@@ -30,7 +30,7 @@ namespace BugsnagUnityPerformance
         {
             _onSpanEnd = onSpanEnd;
             _frameMetricsCollector = frameMetricsCollector;
-            MainThreadDispatchBehaviour.Instance().StartCoroutine(GetConnectionType());
+            MainThreadDispatchBehaviour.Enqueue(GetConnectionType());
         }
 
         public void Configure(PerformanceConfiguration config)

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/SystemMetricsCollector.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/SystemMetricsCollector.cs
@@ -28,8 +28,8 @@ namespace BugsnagUnityPerformance
         public long? PhysicalMemoryInUse;
         // The total physical memory on the device (bytes).
         public long? TotalDeviceMemory;
-
     }
+    
     internal class SystemMetricsCollector : IPhasedStartup
     {
         private bool _cpuMetricsEnabled = true;

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/SystemMetricsCollector.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/SystemMetricsCollector.cs
@@ -163,8 +163,5 @@ namespace BugsnagUnityPerformance
                 TotalDeviceMemory = UnityEngine.Random.Range(0, 1000)
             };
         }
-
-
     }
-
 }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/SystemMetricsCollector.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/SystemMetricsCollector.cs
@@ -92,6 +92,7 @@ namespace BugsnagUnityPerformance
 
         private SystemMetricsSnapshot? GetSystemMetricsSnapshot()
         {
+            return GetTestingMetrics(); 
             if (_platform == RuntimePlatform.Android)
             {
                 return AndroidNative.GetSystemMetricsSnapshot();
@@ -100,10 +101,6 @@ namespace BugsnagUnityPerformance
             {
                 return iOSNative.GetSystemMetricsSnapshot();
             }
-            //return null; // Unsupported platform
-
-            // Uncomment for testing data in the unity editor
-            return GetTestingMetrics(); 
         }
 
         public void OnSpanEnd(Span span)

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/SystemMetricsCollector.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/SystemMetricsCollector.cs
@@ -100,10 +100,10 @@ namespace BugsnagUnityPerformance
             {
                 return iOSNative.GetSystemMetricsSnapshot();
             }
-            return null; // Unsupported platform
+            //return null; // Unsupported platform
 
             // Uncomment for testing data in the unity editor
-            //return GetTestingMetrics(); 
+            return GetTestingMetrics(); 
         }
 
         public void OnSpanEnd(Span span)

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/SystemMetricsCollector.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/SystemMetricsCollector.cs
@@ -1,0 +1,229 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using BugsnagUnityPerformance;
+using UnityEngine;
+namespace BugsnagUnityPerformance
+{
+    internal struct SystemMetricsSnapshot
+    {
+        public long Timestamp;
+        //CPU usage
+        public double ProcessCPUPercent;
+        public double MainThreadCPUPercent;
+        public double MonitorThreadCPUPercent;
+
+        //Android specifics
+        // Free memory (bytes) on the Java heap.
+        public long? FreeMemory;
+        // Total memory (bytes) on the Java heap.
+        public long? TotalMemory;
+        // Max memory (bytes) for the Java heap.
+        public long? MaxMemory;
+        // Proportional Set Size (bytes).
+        public long? PSS;
+
+        //iOS
+        // The current physical memory usage by this process (bytes).
+        public long? PhysicalMemoryInUse;
+        // The total physical memory on the device (bytes).
+        public long? TotalDeviceMemory;
+
+    }
+    internal class SystemMetricsCollector : IPhasedStartup
+    {
+        private bool _cpuMetricsEnabled = true;
+        private bool _memoryMetricsEnabled = true;
+        private List<SystemMetricsSnapshot> _snapshots = new List<SystemMetricsSnapshot>(MAX_SNAPSHOTS);
+        private const int MAX_SNAPSHOTS = 1200; // 20 minutes at 1 second intervals
+        private const float SNAPSHOT_INTERVAL = 1.0f;
+        private RuntimePlatform _platform;
+
+        public SystemMetricsCollector()
+        {
+            _platform = Application.platform;
+            StartPollingForMetrics();
+        }
+        public void Configure(PerformanceConfiguration config)
+        {
+            if (config.EnabledMetrics != null)
+            {
+                _cpuMetricsEnabled = config.EnabledMetrics.CPU;
+                _memoryMetricsEnabled = config.EnabledMetrics.Memory;
+            }
+            else
+            {
+                _cpuMetricsEnabled = false;
+                _memoryMetricsEnabled = false;
+            }
+        }
+
+        public void Start()
+        {
+            // No-op
+        }
+
+        private void StartPollingForMetrics()
+        {
+            MainThreadDispatchBehaviour.Instance().StartCoroutine(PollForMetrics());
+        }
+
+        private IEnumerator PollForMetrics()
+        {
+            if (!_cpuMetricsEnabled && !_memoryMetricsEnabled)
+            {
+                yield break;
+            }
+            while (true)
+            {
+                var snapshot = GetSystemMetricsSnapshot();
+                if (snapshot.HasValue)
+                {
+                    _snapshots.Add(snapshot.Value);
+                    if (_snapshots.Count > MAX_SNAPSHOTS)
+                    {
+                        _snapshots.RemoveAt(0); // Ring-buffer behavior
+                    }
+                }
+
+                yield return new WaitForSeconds(SNAPSHOT_INTERVAL);
+            }
+        }
+
+        private SystemMetricsSnapshot? GetSystemMetricsSnapshot()
+        {
+            if (_platform == RuntimePlatform.Android)
+            {
+                return AndroidNative.GetSystemMetricsSnapshot();
+            }
+            else if (_platform == RuntimePlatform.IPhonePlayer)
+            {
+                return iOSNative.GetSystemMetricsSnapshot();
+            }
+            return GetDummyData(); // Unsupported platform
+        }
+
+        public void OnSpanEnd(Span span)
+        {
+            if (!_cpuMetricsEnabled && !_memoryMetricsEnabled)
+            {
+                return;
+            }
+            if (_snapshots == null || _snapshots.Count == 0)
+                return;
+
+            long startNs = BugsnagPerformanceUtil.GetNanoSeconds(span.StartTime);
+            long endNs = BugsnagPerformanceUtil.GetNanoSeconds(span.EndTime);
+
+            // Snapshot immediately before span start
+            var beforeSnapshot = _snapshots.LastOrDefault(s => s.Timestamp < startNs);
+
+            // Snapshots during span + up to 1.1s after
+            var duringAndAfter = _snapshots
+                .Where(s => s.Timestamp >= startNs && s.Timestamp <= (endNs + 1_100_000_000))
+                .ToList();
+
+            var relevantSnapshots = new List<SystemMetricsSnapshot>();
+            if (beforeSnapshot.Timestamp > 0)
+            {
+                relevantSnapshots.Add(beforeSnapshot);
+            }
+
+            relevantSnapshots.AddRange(duringAndAfter);
+
+            // If still fewer than 2, grab the last 2 available
+            if (relevantSnapshots.Count < 2)
+            {
+                //hold span until we have 2
+            }
+
+            // Must be 2 by now, maybe this check is not needed
+            if (relevantSnapshots.Count > 0)
+            {
+                MetricsFormatter.AttachMetricsToSpan(span, relevantSnapshots);
+            }
+        }
+
+        private SystemMetricsSnapshot GetDummyData()
+        {
+            return new SystemMetricsSnapshot
+            {
+                Timestamp = BugsnagPerformanceUtil.GetNanoSeconds(DateTimeOffset.UtcNow),
+                ProcessCPUPercent = 0.5,
+                MainThreadCPUPercent = 0.6,
+                MonitorThreadCPUPercent = 0.7,
+                FreeMemory = 111,
+                TotalMemory = 222,
+                MaxMemory = 333,
+                PSS = 444,
+                PhysicalMemoryInUse = 555,
+                TotalDeviceMemory = 666
+            };
+        }
+
+
+    }
+
+    internal static class MetricsFormatter
+    {
+        public static void AttachMetricsToSpan(Span span, List<SystemMetricsSnapshot> snapshots)
+        {
+            if (snapshots == null || snapshots.Count == 0)
+                return;
+
+            // === Timestamps ===
+            var timestamps = snapshots.Select(s => s.Timestamp).ToArray();
+            span.SetAttribute("bugsnag.system.cpu_measures_timestamps", timestamps);
+            span.SetAttribute("bugsnag.system.memory.timestamps", timestamps);
+
+            // === CPU ===
+            var processCpu = snapshots.Select(s => s.ProcessCPUPercent).ToArray();
+            var mainThreadCpu = snapshots.Select(s => s.MainThreadCPUPercent).ToArray();
+            var monitorThreadCpu = snapshots.Select(s => s.MonitorThreadCPUPercent).ToArray();
+
+            span.SetAttribute("bugsnag.system.cpu_measures_total", processCpu);
+            span.SetAttribute("bugsnag.system.cpu_measures_main_thread", mainThreadCpu);
+            span.SetAttribute("bugsnag.system.cpu_measures_overhead", monitorThreadCpu);
+
+            span.SetAttribute("bugsnag.metrics.cpu_mean_total", processCpu.Average());
+            span.SetAttribute("bugsnag.system.cpu_mean_main_thread", mainThreadCpu.Average());
+
+            // === Memory ===
+            // Android Java Heap
+            if (snapshots.Any(s => s.TotalMemory.HasValue))
+            {
+                var totalDeviceMemory = snapshots.FirstOrDefault(s => s.TotalMemory.HasValue).TotalMemory ?? 0;
+
+                span.SetAttribute("bugsnag.device.physical_device_memory", totalDeviceMemory);
+
+                var used = snapshots.Select(s => (s.TotalMemory ?? 0) - (s.FreeMemory ?? 0)).ToArray();
+                var size = snapshots.Max(s => s.TotalMemory ?? 0);
+
+                span.SetAttribute("bugsnag.system.memory.spaces.space_names", new[] { "art", "device" });
+
+                span.SetAttribute("bugsnag.system.memory.spaces.device.size", size);
+                span.SetAttribute("bugsnag.system.memory.spaces.device.used", used);
+                span.SetAttribute("bugsnag.system.memory.spaces.device.mean", (long)used.Average());
+
+                span.SetAttribute("bugsnag.system.memory.spaces.art.size", size);
+                span.SetAttribute("bugsnag.system.memory.spaces.art.used", used);
+                span.SetAttribute("bugsnag.system.memory.spaces.art.mean", (long)used.Average());
+            }
+
+            // iOS Physical Memory
+            if (snapshots.Any(s => s.PhysicalMemoryInUse.HasValue))
+            {
+                var physicalUsed = snapshots.Select(s => s.PhysicalMemoryInUse ?? 0).ToArray();
+                var physicalTotal = snapshots.FirstOrDefault(s => s.TotalDeviceMemory.HasValue).TotalDeviceMemory ?? 0;
+
+                span.SetAttribute("bugsnag.device.physical_device_memory", physicalTotal);
+
+                span.SetAttribute("bugsnag.system.memory.spaces.space_names", new[] { "device" });
+                span.SetAttribute("bugsnag.system.memory.spaces.device.size", physicalTotal);
+                span.SetAttribute("bugsnag.system.memory.spaces.device.used", physicalUsed);
+                span.SetAttribute("bugsnag.system.memory.spaces.device.mean", (long)physicalUsed.Average());
+            }
+        }
+    }
+}

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/SystemMetricsCollector.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/SystemMetricsCollector.cs
@@ -44,6 +44,7 @@ namespace BugsnagUnityPerformance
             _platform = Application.platform;
             StartPollingForMetrics();
         }
+        
         public void Configure(PerformanceConfiguration config)
         {
             if (config.EnabledMetrics != null)

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/SystemMetricsCollector.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/SystemMetricsCollector.cs
@@ -111,7 +111,9 @@ namespace BugsnagUnityPerformance
                 return;
             }
             if (_snapshots == null || _snapshots.Count == 0)
+            {
                 return;
+            }
 
             long startNs = BugsnagPerformanceUtil.GetNanoSeconds(span.StartTime);
             long endNs = BugsnagPerformanceUtil.GetNanoSeconds(span.EndTime);

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/SystemMetricsCollector.cs.meta
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/SystemMetricsCollector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b57c0d4d2886d428aa19ec4a5ca57b12
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Tracer.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Tracer.cs
@@ -10,6 +10,7 @@ namespace BugsnagUnityPerformance
     {
         private PerformanceConfiguration _config;
         private FrameMetricsCollector _frameMetricsCollector;
+        private SystemMetricsCollector _systemMetricsCollector;
         private List<Span> _finishedSpanQueue = new List<Span>();
         private List<WeakReference<Span>> _preStartSpans = new List<WeakReference<Span>>();
         private object _queueLock = new object();
@@ -20,11 +21,12 @@ namespace BugsnagUnityPerformance
         private Delivery _delivery;
         private bool _started;
 
-        public Tracer(Sampler sampler, Delivery delivery, FrameMetricsCollector frameMetricsCollector)
+        public Tracer(Sampler sampler, Delivery delivery, FrameMetricsCollector frameMetricsCollector, SystemMetricsCollector systemMetricsCollector)
         {
             _sampler = sampler;
             _delivery = delivery;
             _frameMetricsCollector = frameMetricsCollector;
+            _systemMetricsCollector = systemMetricsCollector;
         }
 
         public void Configure(PerformanceConfiguration config)
@@ -98,6 +100,7 @@ namespace BugsnagUnityPerformance
         public void OnSpanEnd(Span span)
         {
             ApplyFrameRateMetrics(span);
+            ApplySystemMetrics(span);
             if (!_started)
             {
                 lock (_prestartLock)
@@ -115,6 +118,11 @@ namespace BugsnagUnityPerformance
         private void ApplyFrameRateMetrics(Span span)
         {
             _frameMetricsCollector.OnSpanEnd(span);
+        }
+
+        private void ApplySystemMetrics(Span span)
+        {
+            _systemMetricsCollector.OnSpanEnd(span);
         }
 
         public void RunOnEndCallbacks(Span span)

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Models/SpanModel.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Models/SpanModel.cs
@@ -7,7 +7,6 @@ namespace BugsnagUnityPerformance
     internal class SpanModel
     {
         private const int MAXIMUM_ATTRIBUTE_KEY_LENGTH_LIMIT = 128;
-        static readonly DateTimeOffset _unixStart = new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
         public string name;
         public int kind;
         public string spanId;
@@ -25,8 +24,8 @@ namespace BugsnagUnityPerformance
             spanId = span.SpanId;
             traceId = span.TraceId.Replace("-", string.Empty);
             parentSpanId = span.ParentSpanId;
-            startTimeUnixNano = GetNanoSeconds(span.StartTime);
-            endTimeUnixNano = GetNanoSeconds(span.EndTime);
+            startTimeUnixNano = BugsnagPerformanceUtil.GetNanoSeconds(span.StartTime).ToString();
+            endTimeUnixNano = BugsnagPerformanceUtil.GetNanoSeconds(span.EndTime).ToString();
 
             foreach (var attr in span.GetAttributes())
             {
@@ -105,12 +104,6 @@ namespace BugsnagUnityPerformance
                 return strValue.Substring(0, limit) + $"*** {truncatedLength} CHARS TRUNCATED";
             }
             return strValue;
-        }
-
-        private string GetNanoSeconds(DateTimeOffset time)
-        {
-            var duration = time - _unixStart;
-            return (duration.Ticks * 100).ToString();
         }
 
         // This method tells Json.NET whether to serialize the droppedAttributesCount or not.

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Native/AndroidNative.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Native/AndroidNative.cs
@@ -106,16 +106,16 @@ namespace BugsnagUnityPerformance
         {
 #if UNITY_ANDROID && !UNITY_EDITOR
             var snapshot = new SystemMetricsSnapshot();
-            using (var activity = new AndroidJavaClass("com.unity3d.player.UnityPlayer"))
-            {
-                var context = activity.GetStatic<AndroidJavaObject>("currentActivity");
-                var memoryInfo = new AndroidJavaObject("android.app.ActivityManager$MemoryInfo");
-                var activityManager = context.Call<AndroidJavaObject>("getSystemService", "activity");
-                activityManager.Call("getMemoryInfo", memoryInfo);
-                snapshot.FreeMemory = memoryInfo.Get<long>("availMem");
-                snapshot.TotalMemory = memoryInfo.Get<long>("totalMem");
-                snapshot.MaxMemory = memoryInfo.Get<long>("threshold");
-            }
+            // using (var activity = new AndroidJavaClass("com.unity3d.player.UnityPlayer"))
+            // {
+            //     var context = activity.GetStatic<AndroidJavaObject>("currentActivity");
+            //     var memoryInfo = new AndroidJavaObject("android.app.ActivityManager$MemoryInfo");
+            //     var activityManager = context.Call<AndroidJavaObject>("getSystemService", "activity");
+            //     activityManager.Call("getMemoryInfo", memoryInfo);
+            //     snapshot.FreeMemory = memoryInfo.Get<long>("availMem");
+            //     snapshot.TotalMemory = memoryInfo.Get<long>("totalMem");
+            //     snapshot.MaxMemory = memoryInfo.Get<long>("threshold");
+            // }
             return snapshot;
 #endif
 #pragma warning disable CS0162 // Unreachable code detected

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Native/AndroidNative.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Native/AndroidNative.cs
@@ -122,9 +122,7 @@ namespace BugsnagUnityPerformance
             // return dummy value
             return new SystemMetricsSnapshot
             {
-                FreeMemory = 111,
-                TotalMemory = 222,
-                MaxMemory = 333
+                
             };
 #pragma warning restore CS0162 // Unreachable code detected
         }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Native/AndroidNative.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Native/AndroidNative.cs
@@ -102,5 +102,32 @@ namespace BugsnagUnityPerformance
 #pragma warning restore CS0162 // Unreachable code detected
         }
 
+        public static SystemMetricsSnapshot GetSystemMetricsSnapshot()
+        {
+#if UNITY_ANDROID && !UNITY_EDITOR
+            var snapshot = new SystemMetricsSnapshot();
+            using (var activity = new AndroidJavaClass("com.unity3d.player.UnityPlayer"))
+            {
+                var context = activity.GetStatic<AndroidJavaObject>("currentActivity");
+                var memoryInfo = new AndroidJavaObject("android.app.ActivityManager$MemoryInfo");
+                var activityManager = context.Call<AndroidJavaObject>("getSystemService", "activity");
+                activityManager.Call("getMemoryInfo", memoryInfo);
+                snapshot.FreeMemory = memoryInfo.Get<long>("availMem");
+                snapshot.TotalMemory = memoryInfo.Get<long>("totalMem");
+                snapshot.MaxMemory = memoryInfo.Get<long>("threshold");
+            }
+            return snapshot;
+#endif
+#pragma warning disable CS0162 // Unreachable code detected
+            // return dummy value
+            return new SystemMetricsSnapshot
+            {
+                FreeMemory = 111,
+                TotalMemory = 222,
+                MaxMemory = 333
+            };
+#pragma warning restore CS0162 // Unreachable code detected
+        }
+
     }
 }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Native/iOSNative.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Native/iOSNative.cs
@@ -46,5 +46,23 @@ namespace BugsnagUnityPerformance
 #endif
             return null;
         }
+
+        public static SystemMetricsSnapshot GetSystemMetricsSnapshot()
+        {
+#if UNITY_IOS && !UNITY_EDITOR
+            var snapshot = new SystemMetricsSnapshot();
+            snapshot.CpuUsage = GetCpuUsage();
+            snapshot.MemoryUsage = GetMemoryUsage();
+            return snapshot;
+#endif
+#pragma warning disable CS0162 // Unreachable code detected
+            return new SystemMetricsSnapshot
+            {
+                FreeMemory = null,
+                TotalMemory = null,
+                MaxMemory = null
+            };
+#pragma warning restore CS0162 // Unreachable code detected
+        }
     }
 }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Native/iOSNative.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Native/iOSNative.cs
@@ -49,20 +49,7 @@ namespace BugsnagUnityPerformance
 
         public static SystemMetricsSnapshot GetSystemMetricsSnapshot()
         {
-#if UNITY_IOS && !UNITY_EDITOR
-            var snapshot = new SystemMetricsSnapshot();
-            snapshot.CpuUsage = GetCpuUsage();
-            snapshot.MemoryUsage = GetMemoryUsage();
-            return snapshot;
-#endif
-#pragma warning disable CS0162 // Unreachable code detected
-            return new SystemMetricsSnapshot
-            {
-                FreeMemory = null,
-                TotalMemory = null,
-                MaxMemory = null
-            };
-#pragma warning restore CS0162 // Unreachable code detected
+            return new SystemMetricsSnapshot();
         }
     }
 }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformance.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformance.cs
@@ -29,6 +29,7 @@ namespace BugsnagUnityPerformance
         private PersistentState _persistentState;
         private PValueUpdater _pValueUpdater;
         private FrameMetricsCollector _frameMetricsCollector;
+        private SystemMetricsCollector _systemMetricsCollector;
         private static List<WeakReference<Span>> _potentiallyOpenSpans = new List<WeakReference<Span>>();
         private Func<BugsnagNetworkRequestInfo, BugsnagNetworkRequestInfo> _networkRequestCallback;
 
@@ -133,10 +134,11 @@ namespace BugsnagUnityPerformance
             _cacheManager = new CacheManager(Application.persistentDataPath);
             _persistentState = new PersistentState(_cacheManager);
             _frameMetricsCollector = new FrameMetricsCollector();
+            _systemMetricsCollector = new SystemMetricsCollector();
             _sampler = new Sampler(_persistentState);
             _resourceModel = new ResourceModel(_cacheManager);
             _delivery = new Delivery(_resourceModel, _cacheManager, OnProbabilityChanged);
-            _tracer = new Tracer(_sampler, _delivery, _frameMetricsCollector);
+            _tracer = new Tracer(_sampler, _delivery, _frameMetricsCollector, _systemMetricsCollector);
             _spanFactory = new SpanFactory(_tracer.OnSpanEnd, _frameMetricsCollector);
             _appStartHandler = new AppStartHandler(_spanFactory);
             _pValueUpdater = new PValueUpdater(_delivery, _sampler);
@@ -145,6 +147,7 @@ namespace BugsnagUnityPerformance
         private void Configure(PerformanceConfiguration config)
         {
             _frameMetricsCollector.Configure(config);
+            _systemMetricsCollector.Configure(config);
             _spanFactory.Configure(config);
             _networkRequestCallback = config.NetworkRequestCallback;
             _cacheManager.Configure(config);

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformance.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformance.cs
@@ -54,7 +54,7 @@ namespace BugsnagUnityPerformance
             {
                 if (IsStarted)
                 {
-                    MainThreadDispatchBehaviour.Instance().LogWarning(ALREADY_STARTED_WARNING);
+                    MainThreadDispatchBehaviour.LogWarning(ALREADY_STARTED_WARNING);
                     return;
                 }
                 IsStarted = true;
@@ -68,7 +68,7 @@ namespace BugsnagUnityPerformance
 
             if (ReleaseStageEnabled(configuration))
             {
-                MainThreadDispatchBehaviour.Instance().Enqueue(() =>
+                MainThreadDispatchBehaviour.Enqueue(() =>
                 {
                     CreateAppLifecycleListener();
                 });

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformanceSettingsObject.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/BugsnagPerformanceSettingsObject.cs
@@ -105,7 +105,7 @@ namespace BugsnagUnityPerformance
                 }
                 catch (Exception e)
                 {
-                    MainThreadDispatchBehaviour.Instance().LogWarning("Error converting TracePropagationUrl " + urls[i] + " into a regex pattern in settings object: " + e.Message);
+                    MainThreadDispatchBehaviour.LogWarning("Error converting TracePropagationUrl " + urls[i] + " into a regex pattern in settings object: " + e.Message);
                 }
             }
 

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
@@ -55,7 +55,7 @@ namespace BugsnagUnityPerformance
                 }
                 else
                 {
-                    MainThreadDispatchBehaviour.Instance().LogWarning("AttributeStringValueLimit must be greater than 0 and no larger than " + MAXIMUM_ATTRIBUTE_STRING_VALUE_LIMIT);
+                    MainThreadDispatchBehaviour.LogWarning("AttributeStringValueLimit must be greater than 0 and no larger than " + MAXIMUM_ATTRIBUTE_STRING_VALUE_LIMIT);
                 }
             }
         }
@@ -72,7 +72,7 @@ namespace BugsnagUnityPerformance
                 }
                 else
                 {
-                    MainThreadDispatchBehaviour.Instance().LogWarning("AttributeArrayLengthLimit must be greater than 0 and no larger than " + MAXIMUM_ATTRIBUTE_ARRAY_LENGTH_LIMIT);
+                    MainThreadDispatchBehaviour.LogWarning("AttributeArrayLengthLimit must be greater than 0 and no larger than " + MAXIMUM_ATTRIBUTE_ARRAY_LENGTH_LIMIT);
 
                 }
             }
@@ -90,7 +90,7 @@ namespace BugsnagUnityPerformance
                 }
                 else
                 {
-                    MainThreadDispatchBehaviour.Instance().LogWarning("AttributeCountLimit must be greater than 0 and no larger than " + MAXIMUM_ATTRIBUTE_COUNT_LIMIT);
+                    MainThreadDispatchBehaviour.LogWarning("AttributeCountLimit must be greater than 0 and no larger than " + MAXIMUM_ATTRIBUTE_COUNT_LIMIT);
                 }
             }
         }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/Span.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/Span.cs
@@ -365,6 +365,7 @@ namespace BugsnagUnityPerformance
 
         internal void RemoveSystemMemoryMetrics()
         {
+            _attributes.Remove(PHYSICAL_DEVICE_MEMORY_KEY);
             _attributes.Remove(MEMORY_TIMESTAMPS_KEY);
             _attributes.Remove(MEMORY_SPACES_SPACE_NAMES_KEY);
             _attributes.Remove(MEMORY_SPACES_DEVICE_SIZE_KEY);

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/Span.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/Span.cs
@@ -18,7 +18,18 @@ namespace BugsnagUnityPerformance
         private const string FPS_MIN_KEY = "bugsnag.rendering.fps_minimum";
         private const string FPS_AVERAGE_KEY = "bugsnag.rendering.fps_average";
         private const string FPS_TARGET_KEY = "bugsnag.rendering.fps_target";
-
+        private const string CPU_MEASURES_TIMESTAMPS_KEY = "bugsnag.system.cpu_measures_timestamps";
+        private const string MEMORY_TIMESTAMPS_KEY = "bugsnag.system.memory.timestamps";
+        private const string CPU_MEASURES_TOTAL_KEY = "bugsnag.system.cpu_measures_total";
+        private const string CPU_MEASURES_MAIN_THREAD_KEY = "bugsnag.system.cpu_measures_main_thread";
+        private const string CPU_MEASURES_OVERHEAD_KEY = "bugsnag.system.cpu_measures_overhead";
+        private const string CPU_MEAN_TOTAL_KEY = "bugsnag.metrics.cpu_mean_total";
+        private const string CPU_MEAN_MAIN_THREAD_KEY = "bugsnag.system.cpu_mean_main_thread";
+        private const string PHYSICAL_DEVICE_MEMORY_KEY = "bugsnag.device.physical_device_memory";
+        private const string MEMORY_SPACES_SPACE_NAMES_KEY = "bugsnag.system.memory.spaces.space_names";
+        private const string MEMORY_SPACES_DEVICE_SIZE_KEY = "bugsnag.system.memory.spaces.device.size";
+        private const string MEMORY_SPACES_DEVICE_USED_KEY = "bugsnag.system.memory.spaces.device.used";
+        private const string MEMORY_SPACES_DEVICE_MEAN_KEY = "bugsnag.system.memory.spaces.device.mean";
 
         public string Name { get; internal set; }
         internal SpanKind Kind { get; }
@@ -61,7 +72,7 @@ namespace BugsnagUnityPerformance
 
         void LogSpanEndingWarning()
         {
-            MainThreadDispatchBehaviour.Instance().LogWarning($"Attempting to call End on span: {Name} after the span has already ended.");
+            MainThreadDispatchBehaviour.LogWarning($"Attempting to call End on span: {Name} after the span has already ended.");
         }
 
         public void End(DateTimeOffset? endTime = null)
@@ -196,7 +207,7 @@ namespace BugsnagUnityPerformance
         {
             if (_callbackComplete)
             {
-                MainThreadDispatchBehaviour.Instance().LogWarning($"Attempting to set attribute: {key} on span: {Name} after the span has ended.");
+                MainThreadDispatchBehaviour.LogWarning($"Attempting to set attribute: {key} on span: {Name} after the span has ended.");
                 return;
             }
 
@@ -262,12 +273,12 @@ namespace BugsnagUnityPerformance
 
             var totalFrames = endMetrics.TotalFrames - beginningMetrics.TotalFrames;
             SetAttributeInternal(TOTAL_FRAMES_KEY, totalFrames);
-            
+
             if (totalFrames == 0)
             {
                 return;
             }
-            var sumFrametime = endMetrics.FrameTimeSum - beginningMetrics.FrameTimeSum; 
+            var sumFrametime = endMetrics.FrameTimeSum - beginningMetrics.FrameTimeSum;
             var averageFps = (int)(1.0f / (sumFrametime / totalFrames));
 
             SetAttributeInternal(FPS_AVERAGE_KEY, averageFps);
@@ -287,6 +298,78 @@ namespace BugsnagUnityPerformance
             _attributes.Remove(FPS_MIN_KEY);
             _attributes.Remove(FPS_AVERAGE_KEY);
             _attributes.Remove(FPS_TARGET_KEY);
+        }
+
+        internal void CalculateCPUMetrics(List<SystemMetricsSnapshot> snapshots)
+        {
+            // Timestamps
+            var timestamps = snapshots.Select(s => s.Timestamp).ToArray();
+            SetAttribute(CPU_MEASURES_TIMESTAMPS_KEY, timestamps);
+            // CPU
+            var processCpu = snapshots.Select(s => s.ProcessCPUPercent).ToArray();
+            var mainThreadCpu = snapshots.Select(s => s.MainThreadCPUPercent).ToArray();
+            var monitorThreadCpu = snapshots.Select(s => s.MonitorThreadCPUPercent).ToArray();
+
+            SetAttribute(CPU_MEASURES_TOTAL_KEY, processCpu);
+            SetAttribute(CPU_MEASURES_MAIN_THREAD_KEY, mainThreadCpu);
+            SetAttribute(CPU_MEASURES_OVERHEAD_KEY, monitorThreadCpu);
+            SetAttribute(CPU_MEAN_TOTAL_KEY, processCpu.Average());
+            SetAttribute(CPU_MEAN_MAIN_THREAD_KEY, mainThreadCpu.Average());
+        }
+        internal void CalculateMemoryMetrics(List<SystemMetricsSnapshot> snapshots)
+        {
+            // Timestamps
+            var timestamps = snapshots.Select(s => s.Timestamp).ToArray();
+            SetAttribute(MEMORY_TIMESTAMPS_KEY, timestamps);
+
+            // Memory
+            // Android Java Heap
+            if (snapshots.Any(s => s.TotalMemory.HasValue))
+            {
+                var totalDeviceMemory = snapshots.FirstOrDefault(s => s.TotalMemory.HasValue).TotalMemory ?? 0;
+                SetAttribute(PHYSICAL_DEVICE_MEMORY_KEY, totalDeviceMemory);
+
+                var used = snapshots.Select(s => (s.TotalMemory ?? 0) - (s.FreeMemory ?? 0)).ToArray();
+                var size = snapshots.Max(s => s.TotalMemory ?? 0);
+
+                SetAttribute(MEMORY_SPACES_SPACE_NAMES_KEY, new[] { "device" });
+                SetAttribute(MEMORY_SPACES_DEVICE_SIZE_KEY, size);
+                SetAttribute(MEMORY_SPACES_DEVICE_USED_KEY, used);
+                SetAttribute(MEMORY_SPACES_DEVICE_MEAN_KEY, (long)used.Average());
+            }
+
+            // iOS Physical Memory
+            if (snapshots.Any(s => s.PhysicalMemoryInUse.HasValue))
+            {
+                var physicalUsed = snapshots.Select(s => s.PhysicalMemoryInUse ?? 0).ToArray();
+                var physicalTotal = snapshots.FirstOrDefault(s => s.TotalDeviceMemory.HasValue).TotalDeviceMemory ?? 0;
+
+                SetAttribute(PHYSICAL_DEVICE_MEMORY_KEY, physicalTotal);
+
+                SetAttribute(MEMORY_SPACES_SPACE_NAMES_KEY, new[] { "device" });
+                SetAttribute(MEMORY_SPACES_DEVICE_SIZE_KEY, physicalTotal);
+                SetAttribute(MEMORY_SPACES_DEVICE_USED_KEY, physicalUsed);
+                SetAttribute(MEMORY_SPACES_DEVICE_MEAN_KEY, (long)physicalUsed.Average());
+            }
+        }
+
+        internal void RemoveSystemCPUMetrics()
+        {
+            _attributes.Remove(CPU_MEASURES_TIMESTAMPS_KEY);
+            _attributes.Remove(CPU_MEASURES_TOTAL_KEY);
+            _attributes.Remove(CPU_MEASURES_MAIN_THREAD_KEY);
+            _attributes.Remove(CPU_MEASURES_OVERHEAD_KEY);
+            _attributes.Remove(CPU_MEAN_TOTAL_KEY);
+            _attributes.Remove(CPU_MEAN_MAIN_THREAD_KEY);
+        }
+
+        internal void RemoveSystemMemoryMetrics()
+        {
+            _attributes.Remove(MEMORY_TIMESTAMPS_KEY);
+            _attributes.Remove(MEMORY_SPACES_SPACE_NAMES_KEY);
+            _attributes.Remove(MEMORY_SPACES_DEVICE_SIZE_KEY);
+            _attributes.Remove(MEMORY_SPACES_DEVICE_USED_KEY);
+            _attributes.Remove(MEMORY_SPACES_DEVICE_MEAN_KEY);
         }
     }
 }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Util.meta
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Util.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a37957758c7d54403a13ebc8462a267b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Util/BugsnagPerformanceUtil.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Util/BugsnagPerformanceUtil.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+internal class BugsnagPerformanceUtil
+{
+    private static readonly DateTimeOffset _unixStart = new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
+    public static long GetNanoSeconds(DateTimeOffset time)
+    {
+        var duration = time - _unixStart;
+        return duration.Ticks * 100; // 1 tick = 100 nanoseconds
+    }
+}

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Util/BugsnagPerformanceUtil.cs.meta
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Util/BugsnagPerformanceUtil.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4e7fd8cab8efa49669f8f450626aadaf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/BugsnagPerformance/Assets/Scripts/Main.cs
+++ b/BugsnagPerformance/Assets/Scripts/Main.cs
@@ -12,8 +12,8 @@ public class Main : MonoBehaviour
 
     public void Start()
     {
-        var config = BugsnagPerformanceSettingsObject.LoadConfiguration();
-        BugsnagPerformance.Start(config);
+        // var config = BugsnagPerformanceSettingsObject.LoadConfiguration();
+        // BugsnagPerformance.Start(config);
     }
 
     public void DoSpan()
@@ -38,17 +38,17 @@ public class Main : MonoBehaviour
     private IEnumerator SpanRoutine()
     {
         var span = BugsnagPerformance.StartSpan("span " + Guid.NewGuid());
-        span.SetAttribute("my string attribute", "some value");
-        span.SetAttribute("my string[] attribute", new string[]{"a","b","c"});
-        span.SetAttribute("my empty string[] attribute", new string[]{});
-        span.SetAttribute("my int attribute", 42);
-        span.SetAttribute("my int[] attribute", new long[]{1, 2, 3});
-        span.SetAttribute("my bool attribute", true);
-        span.SetAttribute("my bool[] attribute", new bool[]{true, false, true});
-        span.SetAttribute("my double attribute", 3.14);
-        span.SetAttribute("my double[] attribute", new double[]{1.1, 2.2, 3.3});
+        // span.SetAttribute("my string attribute", "some value");
+        // span.SetAttribute("my string[] attribute", new string[]{"a","b","c"});
+        // span.SetAttribute("my empty string[] attribute", new string[]{});
+        // span.SetAttribute("my int attribute", 42);
+        // span.SetAttribute("my int[] attribute", new long[]{1, 2, 3});
+        // span.SetAttribute("my bool attribute", true);
+        // span.SetAttribute("my bool[] attribute", new bool[]{true, false, true});
+        // span.SetAttribute("my double attribute", 3.14);
+        // span.SetAttribute("my double[] attribute", new double[]{1.1, 2.2, 3.3});
 
-        yield return new WaitForSeconds(1.0f);
+        yield return new WaitForSeconds(3.0f);
         span.End();
     }
 

--- a/features/cpu_metrics.feature
+++ b/features/cpu_metrics.feature
@@ -16,15 +16,25 @@ Feature: CPU Metrics
 
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.4.key" equals "bugsnag.system.cpu_measures_total"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.4.value.arrayValue.values" is an array with 5 elements
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double array attribute "bugsnag.system.cpu_measures_total" contains valid percentages
 
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.5.key" equals "bugsnag.system.cpu_measures_main_thread"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.5.value.arrayValue.values" is an array with 5 elements
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double array attribute "bugsnag.system.cpu_measures_main_thread" contains valid percentages
 
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.6.key" equals "bugsnag.system.cpu_measures_overhead"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.6.value.arrayValue.values" is an array with 5 elements
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double array attribute "bugsnag.system.cpu_measures_overhead" contains valid percentages
 
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double attribute "bugsnag.metrics.cpu_mean_total" exists
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double attribute "bugsnag.metrics.cpu_mean_total" is a valid percentage
     
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double attribute "bugsnag.system.cpu_mean_main_thread" exists
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double attribute "bugsnag.system.cpu_mean_main_thread" is a valid percentage
 
 
+  Scenario: Disable Cpu Metrics
+    When I run the game in the "ConfigureCpuMetrics" state
+    And I wait for 1 span
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "BeforeStart"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes" is an array with 4 elements
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" boolean attribute "bugsnag.span.first_class" is true
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "custom"

--- a/features/cpu_metrics.feature
+++ b/features/cpu_metrics.feature
@@ -1,0 +1,30 @@
+Feature: CPU Metrics
+
+  Background:
+    Given I clear the Bugsnag cache
+
+  Scenario: CPU Metrics
+    When I run the game in the "CpuMetrics" state
+    And I wait for 1 span
+
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "CpuMetrics"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes" is an array with 10 elements
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" boolean attribute "bugsnag.span.first_class" is true
+
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.3.key" equals "bugsnag.system.cpu_measures_timestamps"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.3.value.arrayValue.values" is an array with 5 elements
+
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.4.key" equals "bugsnag.system.cpu_measures_total"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.4.value.arrayValue.values" is an array with 5 elements
+
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.5.key" equals "bugsnag.system.cpu_measures_main_thread"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.5.value.arrayValue.values" is an array with 5 elements
+
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.6.key" equals "bugsnag.system.cpu_measures_overhead"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.6.value.arrayValue.values" is an array with 5 elements
+
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double attribute "bugsnag.metrics.cpu_mean_total" exists
+    
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double attribute "bugsnag.system.cpu_mean_main_thread" exists
+
+

--- a/features/fixtures/mazerunner/Assets/Scenes/MainScene.unity
+++ b/features/fixtures/mazerunner/Assets/Scenes/MainScene.unity
@@ -1018,8 +1018,9 @@ GameObject:
   - component: {fileID: 1124192953}
   - component: {fileID: 1124192954}
   - component: {fileID: 1124192955}
+  - component: {fileID: 1124192956}
   m_Layer: 0
-  m_Name: RenderingMetrics
+  m_Name: Metrics
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1063,6 +1064,19 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6bb1e5e240fc2429482d20d392b88135, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ShouldStartNotifier: 0
+--- !u!114 &1124192956
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1124192952}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c113ce13910b243a2816ae49d09bcbc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1294582013

--- a/features/fixtures/mazerunner/Assets/Scenes/MainScene.unity
+++ b/features/fixtures/mazerunner/Assets/Scenes/MainScene.unity
@@ -1019,6 +1019,9 @@ GameObject:
   - component: {fileID: 1124192954}
   - component: {fileID: 1124192955}
   - component: {fileID: 1124192956}
+  - component: {fileID: 1124192957}
+  - component: {fileID: 1124192959}
+  - component: {fileID: 1124192958}
   m_Layer: 0
   m_Name: Metrics
   m_TagString: Untagged
@@ -1077,6 +1080,44 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: c113ce13910b243a2816ae49d09bcbc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ShouldStartNotifier: 0
+--- !u!114 &1124192957
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1124192952}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 771eb92f9120d40eebe7331f7fe7083f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ShouldStartNotifier: 0
+--- !u!114 &1124192958
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1124192952}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ef6b6638c32824cd09e5bc90ba6c791c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1124192959
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1124192952}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 31195cb4a65c4458eb5d46cb119e51bf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1294582013

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenario.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenario.cs
@@ -5,6 +5,7 @@ using System;
 using BugsnagUnityPerformance;
 using System.Reflection;
 using BugsnagUnity;
+using System.Collections;
 
 public class Scenario : MonoBehaviour
 {
@@ -54,6 +55,18 @@ public class Scenario : MonoBehaviour
     public virtual void Run()
     {
 
+    }
+
+    public void DoSpan(string name,float duration)
+    {
+        StartCoroutine(DoSpanWithDuration(name, duration));
+    }
+
+    private IEnumerator DoSpanWithDuration(string name, float duration)
+    {
+        var span = BugsnagPerformance.StartSpan(name);
+        yield return new WaitForSeconds(duration);
+        span.End();
     }
 
     public void DoMultipleSpans(int num)

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Metrics.meta
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Metrics.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ea38d932910614180b39571dfe2626d6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Metrics/ConfigureCpuMetrics.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Metrics/ConfigureCpuMetrics.cs
@@ -1,0 +1,40 @@
+using System.Collections;
+using System.Collections.Generic;
+using BugsnagUnityPerformance;
+using UnityEngine;
+
+public class ConfigureCpuMetrics : Scenario
+{
+
+    Span _beforeStartSpan;
+
+    public override void PreparePerformanceConfig(string apiKey, string host)
+    {
+        base.PreparePerformanceConfig(apiKey, host);
+        SetMaxBatchSize(1);
+        Configuration.EnabledMetrics.CPU = false;
+    }
+
+    public override void StartBugsnag()
+    {
+        _beforeStartSpan = BugsnagPerformance.StartSpan("BeforeStart");
+    }
+
+    public override void Run()
+    {
+        base.Run();
+        StartCoroutine(DoTest());
+    }
+
+    private IEnumerator DoTest()
+    {
+        yield return new WaitForSeconds(2.5f);
+        _beforeStartSpan.End();
+        yield return new WaitForSeconds(2.5f);
+        base.StartBugsnag();
+    }
+
+
+}
+
+

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Metrics/ConfigureCpuMetrics.cs.meta
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Metrics/ConfigureCpuMetrics.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 771eb92f9120d40eebe7331f7fe7083f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Metrics/ConfigureMemoryMetrics.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Metrics/ConfigureMemoryMetrics.cs
@@ -1,0 +1,40 @@
+using System.Collections;
+using System.Collections.Generic;
+using BugsnagUnityPerformance;
+using UnityEngine;
+
+public class ConfigureMemoryMetrics : Scenario
+{
+
+    Span _beforeStartSpan;
+
+    public override void PreparePerformanceConfig(string apiKey, string host)
+    {
+        base.PreparePerformanceConfig(apiKey, host);
+        SetMaxBatchSize(1);
+        Configuration.EnabledMetrics.Memory = false;
+    }
+
+    public override void StartBugsnag()
+    {
+        _beforeStartSpan = BugsnagPerformance.StartSpan("BeforeStart");
+    }
+
+    public override void Run()
+    {
+        base.Run();
+        StartCoroutine(DoTest());
+    }
+
+    private IEnumerator DoTest()
+    {
+        yield return new WaitForSeconds(2.5f);
+        _beforeStartSpan.End();
+        yield return new WaitForSeconds(2.5f);
+        base.StartBugsnag();
+    }
+
+
+}
+
+

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Metrics/ConfigureMemoryMetrics.cs.meta
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Metrics/ConfigureMemoryMetrics.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 31195cb4a65c4458eb5d46cb119e51bf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Metrics/CpuMetrics.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Metrics/CpuMetrics.cs
@@ -1,0 +1,22 @@
+using System.Collections;
+using System.Collections.Generic;
+using BugsnagUnityPerformance;
+using UnityEngine;
+
+public class CpuMetrics : Scenario
+{
+    public override void PreparePerformanceConfig(string apiKey, string host)
+    {
+        base.PreparePerformanceConfig(apiKey, host);
+        Configuration.EnabledMetrics = new EnabledMetrics
+        {
+            CPU = true
+        };
+        SetMaxBatchSize(1);
+    }
+
+    public override void Run()
+    {
+        DoSpan("CpuMetrics", 3f);
+    }
+}

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Metrics/CpuMetrics.cs.meta
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Metrics/CpuMetrics.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c113ce13910b243a2816ae49d09bcbc5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Metrics/MemoryMetrics.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Metrics/MemoryMetrics.cs
@@ -1,0 +1,22 @@
+using System.Collections;
+using System.Collections.Generic;
+using BugsnagUnityPerformance;
+using UnityEngine;
+
+public class MemoryMetrics : Scenario
+{
+    public override void PreparePerformanceConfig(string apiKey, string host)
+    {
+        base.PreparePerformanceConfig(apiKey, host);
+        Configuration.EnabledMetrics = new EnabledMetrics
+        {
+            Memory = true
+        };
+        SetMaxBatchSize(1);
+    }
+
+    public override void Run()
+    {
+        DoSpan("MemoryMetrics", 3f);
+    }
+}

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Metrics/MemoryMetrics.cs.meta
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Metrics/MemoryMetrics.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ef6b6638c32824cd09e5bc90ba6c791c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Metrics/RenderMetrics.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Scenarios/Metrics/RenderMetrics.cs
@@ -11,6 +11,8 @@ public class RenderMetrics : Scenario
 
     const int NUM_SLOW_FRAMES_TO_DO = 10;
     const int NUM_FROZEN_FRAMES_TO_DO = 1;
+    const int TOTAL_FRAMES_TO_DO = 100;
+
 
     int _frameCount;
 
@@ -64,7 +66,7 @@ public class RenderMetrics : Scenario
             _frozenFramesDone++;
             return;
         }
-        if (_frameCount < (100 - NUM_SLOW_FRAMES_TO_DO - NUM_FROZEN_FRAMES_TO_DO))
+        if (_frameCount < (TOTAL_FRAMES_TO_DO - NUM_SLOW_FRAMES_TO_DO - NUM_FROZEN_FRAMES_TO_DO))
         {
             _frameCount++;
             return;

--- a/features/memory_metrics.feature
+++ b/features/memory_metrics.feature
@@ -1,0 +1,37 @@
+Feature: Memory Metrics
+
+  Background:
+    Given I clear the Bugsnag cache
+
+  Scenario: Memory Metrics
+    When I run the game in the "MemoryMetrics" state
+    And I wait for 1 span
+
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "MemoryMetrics"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes" is an array with 10 elements
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" boolean attribute "bugsnag.span.first_class" is true
+
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.3.key" equals "bugsnag.system.memory.timestamps"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.3.value.arrayValue.values" is an array with 5 elements
+
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "bugsnag.device.physical_device_memory" is greater than 0
+
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.5.key" equals "bugsnag.system.memory.spaces.space_names"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.5.value.arrayValue.values" is an array with 1 elements
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.5.value.arrayValue.values.0.stringValue" equals "device"
+
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "bugsnag.system.memory.spaces.device.size" is greater than 0
+
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.7.key" equals "bugsnag.system.memory.spaces.device.used"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.7.value.arrayValue.values" is an array with 5 elements
+
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "bugsnag.system.memory.spaces.device.mean" is greater than 0
+
+
+  Scenario: Disable Memory Metrics
+    When I run the game in the "ConfigureMemoryMetrics" state
+    And I wait for 1 span
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "BeforeStart"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes" is an array with 4 elements
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" boolean attribute "bugsnag.span.first_class" is true
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "bugsnag.span.category" equals "custom"

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -212,3 +212,66 @@ end
 Then('the span named {string} is not first class') do |span_name|
   check_span_first_class(span_name, false)
 end
+
+def check_valid_percentage(value, field_name, attribute_name, request_type)
+  Maze.check.operator(
+    value, 
+    :>=, 
+    0.0,
+    "Attribute '#{attribute_name}' in '#{field_name}' is less than 0% for request type '#{request_type}': #{value}"
+  )
+  Maze.check.operator(
+    value, 
+    :<=, 
+    100.0,
+    "Attribute '#{attribute_name}' in '#{field_name}' is greater than 100% for request type '#{request_type}': #{value}"
+  )
+end
+
+When('the {request_type} payload field {string} double attribute {string} is a valid percentage') do |request_type, field_name, attribute_name|
+  list = Maze::Server.list_for(request_type)
+  attributes = Maze::Helper.read_key_path(list.current[:body], "#{field_name}.attributes")
+  Maze.check.not_nil(attributes, "No attributes found for '#{field_name}' in request type '#{request_type}'.")
+
+  attr = attributes.find { |a| a['key'] == attribute_name }
+  Maze.check.not_nil(
+    attr,
+    "No attribute named '#{attribute_name}' was found in '#{field_name}' for request type '#{request_type}'."
+  )
+
+  value = attr.dig('value', 'doubleValue')
+  Maze.check.not_nil(
+    value,
+    "Attribute '#{attribute_name}' in '#{field_name}' is missing a doubleValue."
+  )
+
+  float_value = value.to_f
+  check_valid_percentage(float_value, field_name, attribute_name, request_type)
+end
+
+When('the {request_type} payload field {string} double array attribute {string} contains valid percentages') do |request_type, field_name, attribute_name|
+  list = Maze::Server.list_for(request_type)
+  attributes = Maze::Helper.read_key_path(list.current[:body], "#{field_name}.attributes")
+  Maze.check.not_nil(attributes, "No attributes found for '#{field_name}' in request type '#{request_type}'.")
+
+  attr = attributes.find { |a| a['key'] == attribute_name }
+  Maze.check.not_nil(
+    attr,
+    "No attribute named '#{attribute_name}' was found in '#{field_name}' for request type '#{request_type}'."
+  )
+
+  array_value = attr.dig('value', 'arrayValue', 'values')
+  Maze.check.not_nil(
+    array_value,
+    "Attribute '#{attribute_name}' in '#{field_name}' is not an arrayValue or is missing 'values' key."
+  )
+
+  # Check each element is in the valid percentage range
+  array_value.each do |element|
+    double_val_raw = element['doubleValue']
+    Maze.check.not_nil(double_val_raw, "Expected a 'doubleValue' in the array but got: #{element}")
+
+    float_value = double_val_raw.to_f
+    check_valid_percentage(float_value, field_name, attribute_name, request_type)
+  end
+end


### PR DESCRIPTION
## Goal

Setup the csharp layer of CPU and Memory metrics so that it is working as expected with dummy data before adding native code to get real data from the native runtimes.

## Changeset

- Update the `MainThreadDispatchBehaviour` so that it's possible to queue main thread activities before the first unity scene has loaded.
- Added `SystemMetricsSnapshot` struct.
- Added `SystemMetricsCollector` class for polling and handling system metric data.
- Updated the tracer to delay all spans by 2 seconds to ensure that they have enough metrics samples.
- Added `BugsnagPerformanceUtil` class to allow for nanosecond time stamp generation across the code base.
- Added unused placeholder methods to `AndroidNative` and `iOSNative` classes.
- Updated the `Span` class for formatting and adding/removing the new attributes.

## Testing

Added new tests that use dummy data to make sure config and basic processing is working. These tests will be adapted to use real data once the native components are added.