### PR TITLE
[PLAT-14104] Update Unity Performance CI Queues

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ aliases:
   - &2020 "2020.3.48f1"
 
 agents:
-  queue: macos-14-isolated
+  queue: macos-14
 
 steps:
   - label: Verify code formatting

--- a/.buildkite/unity.2020.full.yml
+++ b/.buildkite/unity.2020.full.yml
@@ -125,6 +125,8 @@ steps:
   - group: ":test_tube: E2E Tests Unity 2020"
     steps:
       - label: Run MacOS e2e tests for Unity 2020
+        agents:
+          queue: macos-14-isolated
         timeout_in_minutes: 30
         depends_on: build-macos-fixture-2020
         env:

--- a/.buildkite/unity.2020.full.yml
+++ b/.buildkite/unity.2020.full.yml
@@ -2,7 +2,7 @@ aliases:
   - &2020 "2020.3.48f1"
 
 agents:
-  queue: macos-14-isolated
+  queue: macos-14
 
 steps:
   - group: ":hammer: Build Unity 2020 Test Fixtures"

--- a/.buildkite/unity.2021.full.yml
+++ b/.buildkite/unity.2021.full.yml
@@ -2,7 +2,7 @@ aliases:
   - &2021 "2021.3.45f1"
 
 agents:
-  queue: macos-14-isolated
+  queue: macos-14
 
 steps:
   - group: ":hammer: Build Unity 2021 Test Fixtures"

--- a/.buildkite/unity.2021.full.yml
+++ b/.buildkite/unity.2021.full.yml
@@ -95,6 +95,8 @@ steps:
               limit: 1
 
       - label: ':ios: Build iOS DEV test fixture for Unity 2021'
+        agents:
+          queue: macos-14-isolated
         timeout_in_minutes: 10
         key: build-ios-dev-fixture-2021
         depends_on: generate-dev-fixture-project-2021
@@ -119,6 +121,8 @@ steps:
   - group: ":test_tube: E2E Tests Unity 2021"
     steps:
       - label: Run WebGL DEV e2e tests for Unity 2021
+        agents:
+          queue: macos-14-isolated
         timeout_in_minutes: 20
         depends_on: build-webgl-dev-fixture-2021
         env:
@@ -181,6 +185,8 @@ steps:
               limit: 1
 
       - label: Run MacOS DEV e2e tests for Unity 2021
+        agents:
+          queue: macos-14-isolated
         timeout_in_minutes: 30
         depends_on: build-macos-dev-fixture-2021
         env:

--- a/.buildkite/unity.2021.yml
+++ b/.buildkite/unity.2021.yml
@@ -141,6 +141,8 @@ steps:
   - group: ":test_tube: E2E Tests Unity 2021"
     steps:
       - label: Run WebGL e2e tests for Unity 2021
+        agents:
+          queue: macos-14-isolated
         timeout_in_minutes: 20
         depends_on: build-webgl-fixture-2021
         env:
@@ -185,6 +187,8 @@ steps:
           - features/scripts/run-windows-ci-tests.sh release
 
       - label: Run MacOS e2e tests for Unity 2021
+        agents:
+          queue: macos-14-isolated
         timeout_in_minutes: 30
         depends_on: build-macos-fixture-2021
         env:

--- a/.buildkite/unity.2021.yml
+++ b/.buildkite/unity.2021.yml
@@ -2,7 +2,7 @@ aliases:
   - &2021 "2021.3.45f1"
 
 agents:
-  queue: macos-14-isolated
+  queue: macos-14
 
 steps:
   - group: ":hammer: Build Unity 2021 Test Fixtures"

--- a/.buildkite/unity.2022.full.yml
+++ b/.buildkite/unity.2022.full.yml
@@ -1,5 +1,5 @@
 aliases:
-  - &2022 "2022.3.57f1"
+  - &2022 "2022.3.61f1"
 
 agents:
   queue: macos-14

--- a/.buildkite/unity.2022.full.yml
+++ b/.buildkite/unity.2022.full.yml
@@ -2,7 +2,7 @@ aliases:
   - &2022 "2022.3.57f1"
 
 agents:
-  queue: macos-14-isolated
+  queue: macos-14
 
 steps:
   - group: ":hammer: Build Unity 2022 Test Fixtures"

--- a/.buildkite/unity.2022.full.yml
+++ b/.buildkite/unity.2022.full.yml
@@ -121,6 +121,8 @@ steps:
   - group: ":test_tube: E2E Tests Unity 2022"
     steps:
       - label: Run MacOS e2e tests for Unity 2022
+        agents:
+          queue: macos-14-isolated
         timeout_in_minutes: 30
         depends_on: build-macos-fixture-2022
         env:

--- a/.buildkite/unity.6000.full.yml
+++ b/.buildkite/unity.6000.full.yml
@@ -1,5 +1,5 @@
 aliases:
-  - &6000 "6000.0.36f1"
+  - &6000 "6000.0.47f1"
 
 agents:
   queue: macos-14

--- a/.buildkite/unity.6000.full.yml
+++ b/.buildkite/unity.6000.full.yml
@@ -121,6 +121,8 @@ steps:
   - group: ":test_tube: E2E Tests Unity 6000"
     steps:
       - label: Run MacOS e2e tests for Unity 6000
+        agents:
+          queue: macos-14-isolated
         timeout_in_minutes: 30
         depends_on: build-macos-fixture-6000
         env:

--- a/.buildkite/unity.6000.full.yml
+++ b/.buildkite/unity.6000.full.yml
@@ -2,7 +2,7 @@ aliases:
   - &6000 "6000.0.36f1"
 
 agents:
-  queue: macos-14-isolated
+  queue: macos-14
 
 steps:
   - group: ":hammer: Build Unity 6000 Test Fixtures"


### PR DESCRIPTION
## Goal

Bump the versions of Unity installs to match what is installed on the box.

Move everything but E2E tests to the general queue

## Testing

Covered by CI