### PR TITLE
add cocoa system metrics

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ aliases:
   - &2020 "2020.3.48f1"
 
 agents:
-  queue: macos-14
+  queue: macos-14-isolated
 
 steps:
   - label: Verify code formatting
@@ -27,6 +27,11 @@ steps:
       automatic:
         - exit_status: '*'
           limit: 1
+    agents:
+      queue: macos-14-unity-isolated
+    concurrency: 1
+    concurrency_group: "unity-license-server"
+    concurrency_method: eager
 
   - label: Build size impact reporting
     depends_on: build-artifacts

--- a/.buildkite/unity.2020.full.yml
+++ b/.buildkite/unity.2020.full.yml
@@ -2,7 +2,7 @@ aliases:
   - &2020 "2020.3.48f1"
 
 agents:
-  queue: macos-14
+  queue: macos-14-isolated
 
 steps:
   - group: ":hammer: Build Unity 2020 Test Fixtures"

--- a/.buildkite/unity.2021.full.yml
+++ b/.buildkite/unity.2021.full.yml
@@ -2,7 +2,7 @@ aliases:
   - &2021 "2021.3.45f1"
 
 agents:
-  queue: macos-14
+  queue: macos-14-isolated
 
 steps:
   - group: ":hammer: Build Unity 2021 Test Fixtures"

--- a/.buildkite/unity.2021.yml
+++ b/.buildkite/unity.2021.yml
@@ -2,7 +2,7 @@ aliases:
   - &2021 "2021.3.45f1"
 
 agents:
-  queue: macos-14
+  queue: macos-14-isolated
 
 steps:
   - group: ":hammer: Build Unity 2021 Test Fixtures"

--- a/.buildkite/unity.2022.full.yml
+++ b/.buildkite/unity.2022.full.yml
@@ -2,7 +2,7 @@ aliases:
   - &2022 "2022.3.57f1"
 
 agents:
-  queue: macos-14
+  queue: macos-14-isolated
 
 steps:
   - group: ":hammer: Build Unity 2022 Test Fixtures"

--- a/.buildkite/unity.6000.full.yml
+++ b/.buildkite/unity.6000.full.yml
@@ -2,7 +2,7 @@ aliases:
   - &6000 "6000.0.36f1"
 
 agents:
-  queue: macos-14
+  queue: macos-14-isolated
 
 steps:
   - group: ":hammer: Build Unity 6000 Test Fixtures"

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Plugins/iOS/BugsnagPerformanceMetrics.mm
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Plugins/iOS/BugsnagPerformanceMetrics.mm
@@ -1,24 +1,57 @@
 #import <mach/mach.h>
 #import <mach/mach_host.h>
-#import <mach/mach_time.h> 
-#import <sys/time.h>
-#import <pthread.h>
+#import <mach/mach_time.h>
 #import <Foundation/Foundation.h>
 
-static inline double timeInSeconds()
+#pragma mark ‑‑ helpers
+// --------------------------------------------------------------------
+
+// Convert a Mach time_value_t (sec / µsec) pair to micro‑seconds
+static inline uint64_t tv_to_us(time_value_t tv)
 {
-    mach_timebase_info_data_t info;
-    mach_timebase_info(&info);
-    return (double)mach_absolute_time() * (double)info.numer / (double)info.denom / 1e9;
+    return ((uint64_t)tv.seconds * 1000000ULL) + tv.microseconds;
 }
+
+// Fast monotonic clock → seconds (double)
+static inline double monotonic_seconds(void)
+{
+    static mach_timebase_info_data_t tb;
+    mach_timebase_info(&tb);
+    return ((double)mach_absolute_time() * tb.numer) /
+           ((double)tb.denom * 1e9);
+}
+
+// Generic sampler that turns “total ticks” into “% since last call”
+static inline double cpu_percent(uint64_t   nowTicks,
+                                 uint64_t & lastTicks,
+                                 double   & lastWall)
+{
+    const double nowWall = monotonic_seconds();
+
+    if (lastWall == 0.0) {        // first sample
+        lastTicks = nowTicks;
+        lastWall  = nowWall;
+        return 0.0;
+    }
+
+    const double deltaCpu  = (double)(nowTicks - lastTicks) / 1e6; // µs → s
+    const double deltaWall = nowWall - lastWall;
+
+    lastTicks = nowTicks;
+    lastWall  = nowWall;
+
+    return (deltaWall <= 0.0) ? 0.0 : (deltaCpu / deltaWall) * 100.0;
+}
+
+#pragma mark ‑‑ exported C API
+// --------------------------------------------------------------------
 
 extern "C" {
 
-/// Process CPU percent (user+system) since the last call.
-double bugsnag_unity_performance_process_cpu_percent()
+double bugsnag_unity_performance_process_cpu_percent(void)
 {
-    static uint64_t lastTotalTicks = 0;
-    static double   lastWallClock  = 0.0;
+    static uint64_t lastTicks = 0;
+    static double   lastWall  = 0.0;
 
     task_basic_info_data_t tinfo;
     mach_msg_type_number_t count = TASK_BASIC_INFO_COUNT;
@@ -26,71 +59,43 @@ double bugsnag_unity_performance_process_cpu_percent()
                   (task_info_t)&tinfo, &count) != KERN_SUCCESS)
         return -1.0;
 
-    uint64_t nowTicks = tinfo.user_time.seconds  * 1e6 + tinfo.user_time.microseconds +
-                        tinfo.system_time.seconds * 1e6 + tinfo.system_time.microseconds;
-    double   nowClock = timeInSeconds();
+    const uint64_t nowTicks =
+        tv_to_us(tinfo.user_time) + tv_to_us(tinfo.system_time);
 
-    if (lastWallClock == 0) { // first sample
-        lastTotalTicks = nowTicks;
-        lastWallClock  = nowClock;
-        return 0.0;
-    }
-
-    double deltaCpu   = (double)(nowTicks - lastTotalTicks) / 1e6; // µs → s
-    double deltaTime  = nowClock - lastWallClock;
-    lastTotalTicks    = nowTicks;
-    lastWallClock     = nowClock;
-
-    if (deltaTime <= 0.0) return 0.0;
-    return (deltaCpu / deltaTime) * 100.0;
+    return cpu_percent(nowTicks, lastTicks, lastWall);
 }
 
-/// CPU percent for the main Unity thread only.
-double bugsnag_unity_performance_main_thread_cpu_percent()
+double bugsnag_unity_performance_main_thread_cpu_percent(void)
 {
-    static thread_t mainThread      = mach_thread_self(); // first call happens on main
-    static uint64_t lastTotalTicks  = 0;
-    static double   lastWallClock   = 0.0;
+    static thread_t  mainThread = mach_thread_self(); // captured on first call
+    static uint64_t  lastTicks  = 0;
+    static double    lastWall   = 0.0;
 
     thread_basic_info_data_t info;
-    mach_msg_type_number_t count = THREAD_BASIC_INFO_COUNT;
+    mach_msg_type_number_t   count = THREAD_BASIC_INFO_COUNT;
     if (thread_info(mainThread, THREAD_BASIC_INFO,
                     (thread_info_t)&info, &count) != KERN_SUCCESS)
         return -1.0;
 
-    uint64_t nowTicks = info.user_time.seconds  * 1e6 + info.user_time.microseconds +
-                        info.system_time.seconds * 1e6 + info.system_time.microseconds;
-    double   nowClock = timeInSeconds();
+    const uint64_t nowTicks =
+        tv_to_us(info.user_time) + tv_to_us(info.system_time);
 
-    if (lastWallClock == 0) {
-        lastTotalTicks = nowTicks;
-        lastWallClock  = nowClock;
-        return 0.0;
-    }
-
-    double deltaCpu   = (double)(nowTicks - lastTotalTicks) / 1e6;
-    double deltaTime  = nowClock - lastWallClock;
-    lastTotalTicks    = nowTicks;
-    lastWallClock     = nowClock;
-
-    if (deltaTime <= 0.0) return 0.0;
-    return (deltaCpu / deltaTime) * 100.0;
+    return cpu_percent(nowTicks, lastTicks, lastWall);
 }
 
-/// Bytes of physical memory in use by this process (resident size)
-uint64_t bugsnag_unity_performance_physical_memory_in_use()
+uint64_t bugsnag_unity_performance_physical_memory_in_use(void)
 {
     mach_task_basic_info_data_t info;
-    mach_msg_type_number_t count = MACH_TASK_BASIC_INFO_COUNT;
+    mach_msg_type_number_t      count = MACH_TASK_BASIC_INFO_COUNT;
     if (task_info(mach_task_self(), MACH_TASK_BASIC_INFO,
                   (task_info_t)&info, &count) != KERN_SUCCESS)
         return 0;
     return info.resident_size;
 }
 
-/// Total bytes of RAM on the device
-uint64_t bugsnag_unity_performance_total_device_memory()
+uint64_t bugsnag_unity_performance_total_device_memory(void)
 {
     return [[NSProcessInfo processInfo] physicalMemory];
 }
+
 } // extern "C"

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Plugins/iOS/BugsnagPerformanceMetrics.mm
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Plugins/iOS/BugsnagPerformanceMetrics.mm
@@ -1,0 +1,95 @@
+#import <mach/mach.h>
+#import <mach/mach_host.h>
+#import <sys/time.h>
+#import <pthread.h>
+#import <Foundation/Foundation.h>
+
+static inline double timeInSeconds()
+{
+    mach_timebase_info_data_t info;
+    mach_timebase_info(&info);
+    return (double)mach_absolute_time() * (double)info.numer / (double)info.denom / 1e9;
+}
+
+extern "C" {
+
+/// Process CPU percent (user+system) since the last call.
+double bugsnag_unity_performance_process_cpu_percent()
+{
+    static uint64_t lastTotalTicks = 0;
+    static double   lastWallClock  = 0.0;
+
+    task_basic_info_data_t tinfo;
+    mach_msg_type_number_t count = TASK_BASIC_INFO_COUNT;
+    if (task_info(mach_task_self(), TASK_BASIC_INFO,
+                  (task_info_t)&tinfo, &count) != KERN_SUCCESS)
+        return -1.0;
+
+    uint64_t nowTicks = tinfo.user_time.seconds  * 1e6 + tinfo.user_time.microseconds +
+                        tinfo.system_time.seconds * 1e6 + tinfo.system_time.microseconds;
+    double   nowClock = timeInSeconds();
+
+    if (lastWallClock == 0) { // first sample
+        lastTotalTicks = nowTicks;
+        lastWallClock  = nowClock;
+        return 0.0;
+    }
+
+    double deltaCpu   = (double)(nowTicks - lastTotalTicks) / 1e6; // µs → s
+    double deltaTime  = nowClock - lastWallClock;
+    lastTotalTicks    = nowTicks;
+    lastWallClock     = nowClock;
+
+    if (deltaTime <= 0.0) return 0.0;
+    return (deltaCpu / deltaTime) * 100.0;
+}
+
+/// CPU percent for the main Unity thread only.
+double bugsnag_unity_performance_main_thread_cpu_percent()
+{
+    static thread_t mainThread      = mach_thread_self(); // first call happens on main
+    static uint64_t lastTotalTicks  = 0;
+    static double   lastWallClock   = 0.0;
+
+    thread_basic_info_data_t info;
+    mach_msg_type_number_t count = THREAD_BASIC_INFO_COUNT;
+    if (thread_info(mainThread, THREAD_BASIC_INFO,
+                    (thread_info_t)&info, &count) != KERN_SUCCESS)
+        return -1.0;
+
+    uint64_t nowTicks = info.user_time.seconds  * 1e6 + info.user_time.microseconds +
+                        info.system_time.seconds * 1e6 + info.system_time.microseconds;
+    double   nowClock = timeInSeconds();
+
+    if (lastWallClock == 0) {
+        lastTotalTicks = nowTicks;
+        lastWallClock  = nowClock;
+        return 0.0;
+    }
+
+    double deltaCpu   = (double)(nowTicks - lastTotalTicks) / 1e6;
+    double deltaTime  = nowClock - lastWallClock;
+    lastTotalTicks    = nowTicks;
+    lastWallClock     = nowClock;
+
+    if (deltaTime <= 0.0) return 0.0;
+    return (deltaCpu / deltaTime) * 100.0;
+}
+
+/// Bytes of physical memory in use by this process (resident size)
+uint64_t bugsnag_unity_performance_physical_memory_in_use()
+{
+    mach_task_basic_info_data_t info;
+    mach_msg_type_number_t count = MACH_TASK_BASIC_INFO_COUNT;
+    if (task_info(mach_task_self(), MACH_TASK_BASIC_INFO,
+                  (task_info_t)&info, &count) != KERN_SUCCESS)
+        return 0;
+    return info.resident_size;
+}
+
+/// Total bytes of RAM on the device
+uint64_t bugsnag_unity_performance_total_device_memory()
+{
+    return [[NSProcessInfo processInfo] physicalMemory];
+}
+} // extern "C"

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Plugins/iOS/BugsnagPerformanceMetrics.mm
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Plugins/iOS/BugsnagPerformanceMetrics.mm
@@ -67,9 +67,9 @@ double bugsnag_unity_performance_process_cpu_percent(void)
 
 double bugsnag_unity_performance_main_thread_cpu_percent(void)
 {
-    static thread_t  mainThread = mach_thread_self(); // captured on first call
-    static uint64_t  lastTicks  = 0;
-    static double    lastWall   = 0.0;
+    static thread_t mainThread = mach_thread_self(); // captured on first call
+    static uint64_t lastTicks  = 0;
+    static double   lastWall   = 0.0;
 
     thread_basic_info_data_t info;
     mach_msg_type_number_t   count = THREAD_BASIC_INFO_COUNT;

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Plugins/iOS/BugsnagPerformanceMetrics.mm
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Plugins/iOS/BugsnagPerformanceMetrics.mm
@@ -1,5 +1,6 @@
 #import <mach/mach.h>
 #import <mach/mach_host.h>
+#import <mach/mach_time.h> 
 #import <sys/time.h>
 #import <pthread.h>
 #import <Foundation/Foundation.h>

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Plugins/iOS/BugsnagPerformanceMetrics.mm
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Plugins/iOS/BugsnagPerformanceMetrics.mm
@@ -22,9 +22,9 @@ static inline double monotonic_seconds(void)
 }
 
 // Generic sampler that turns “total ticks” into “% since last call”
-static inline double cpu_percent(uint64_t   nowTicks,
-                                 uint64_t & lastTicks,
-                                 double   & lastWall)
+static inline double cpu_percent(uint64_t  nowTicks,
+                                 uint64_t &lastTicks,
+                                 double   &lastWall)
 {
     const double nowWall = monotonic_seconds();
 

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Plugins/iOS/BugsnagPerformanceMetrics.mm.meta
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Plugins/iOS/BugsnagPerformanceMetrics.mm.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 0f54a2cd01fe04703976b2654caccdab
+guid: e0f81b9daeee344f2be52f29c1c97cdf
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2
@@ -49,7 +49,7 @@ PluginImporter:
     second:
       enabled: 0
       settings:
-        CPU: None
+        CPU: AnyCPU
   - first:
       Standalone: OSXUniversal
     second:
@@ -61,13 +61,13 @@ PluginImporter:
     second:
       enabled: 0
       settings:
-        CPU: None
+        CPU: AnyCPU
   - first:
       Standalone: Win64
     second:
       enabled: 0
       settings:
-        CPU: None
+        CPU: AnyCPU
   - first:
       iPhone: iOS
     second:

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/SystemMetricsCollector.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/SystemMetricsCollector.cs
@@ -128,17 +128,17 @@ namespace BugsnagUnityPerformance
             }
 
             relevantSnapshots.AddRange(duringAndAfter);
-            if (relevantSnapshots.Count > 0)
+
+            if (_memoryMetricsEnabled && relevantSnapshots.Count > 0)
             {
-                if (_cpuMetricsEnabled)
-                {
-                    span.CalculateCPUMetrics(relevantSnapshots);
-                }
-                if (_memoryMetricsEnabled)
-                {
-                    span.CalculateMemoryMetrics(relevantSnapshots);
-                }
+                span.ApplyMemoryMetrics(relevantSnapshots);
             }
+            // We require minimum 2 snapshots to calculate CPU metrics and sometimes this is not possible
+            if (_cpuMetricsEnabled && relevantSnapshots.Count > 1)
+            {
+                span.ApplyCPUMetrics(relevantSnapshots);
+            }
+
         }
     }
 }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Tracer.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Tracer.cs
@@ -172,7 +172,7 @@ namespace BugsnagUnityPerformance
         private void AddSpanToQueue(Span span)
         {
             // Delay adding to the queue to ensure that both pre start spans and later spans have enough system metric snapshots attached.
-           MainThreadDispatchBehaviour.Enqueue(AddToQueueDelayed(span));
+            MainThreadDispatchBehaviour.Enqueue(AddToQueueDelayed(span));
         }
 
         private IEnumerator AddToQueueDelayed(Span span)

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Tracer.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Tracer.cs
@@ -104,21 +104,12 @@ namespace BugsnagUnityPerformance
         public void OnSpanEnd(Span span)
         {
             ApplyFrameRateMetrics(span);
-            // Delay the span end processing to allow for any additional metrics to be collected
-            MainThreadDispatchBehaviour.Enqueue(DelayedOnSpanEnd(span));
-        }
-
-        private IEnumerator DelayedOnSpanEnd(Span span)
-        {
-            yield return new WaitForSeconds(2.0f);
-            ApplySystemMetrics(span);
             if (!_started)
             {
                 lock (_prestartLock)
                 {
                     _preStartSpans.Add(new WeakReference<Span>(span));
                 }
-                yield break;
             }
             else
             {
@@ -178,9 +169,16 @@ namespace BugsnagUnityPerformance
                 }
             }
         }
-
         private void AddSpanToQueue(Span span)
         {
+            // Delay adding to the queue to ensure that both pre start spans and later spans have enough system metric snapshots attached.
+           MainThreadDispatchBehaviour.Enqueue(AddToQueueDelayed(span));
+        }
+
+        private IEnumerator AddToQueueDelayed(Span span)
+        {
+            yield return new WaitForSeconds(2);
+            ApplySystemMetrics(span);
             var deliverBatch = false;
             lock (_queueLock)
             {

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Native/iOSNative.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Native/iOSNative.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
-#if UNITY_IOS //&& !UNITY_EDITOR
+#if UNITY_IOS && !UNITY_EDITOR
 using System.Runtime.InteropServices;
 #endif
 using UnityEngine;

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Native/iOSNative.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Native/iOSNative.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
-#if UNITY_IOS && !UNITY_EDITOR
+#if UNITY_IOS //&& !UNITY_EDITOR
 using System.Runtime.InteropServices;
 #endif
 using UnityEngine;
@@ -14,13 +14,18 @@ namespace BugsnagUnityPerformance
 #if UNITY_IOS && !UNITY_EDITOR
         [DllImport(Import)]
         internal static extern string bugsnag_unity_performance_getBundleVersion();
-
         [DllImport(Import)]
         internal static extern string bugsnag_unity_performance_get_arch();
-
         [DllImport(Import)]
         internal static extern string bugsnag_unity_performance_get_os_version();
-        
+        [DllImport(Import)]
+        static extern double bugsnag_unity_performance_process_cpu_percent();
+        [DllImport(Import)]
+        static extern double bugsnag_unity_performance_main_thread_cpu_percent();
+        [DllImport(Import)]
+        static extern ulong bugsnag_unity_performance_physical_memory_in_use();
+        [DllImport(Import)]
+        static extern ulong bugsnag_unity_performance_total_device_memory();
 #endif
 
         public static string GetBundleVersion()
@@ -47,9 +52,25 @@ namespace BugsnagUnityPerformance
             return null;
         }
 
-        public static SystemMetricsSnapshot GetSystemMetricsSnapshot()
+
+        public static SystemMetricsSnapshot? GetSystemMetricsSnapshot()
         {
-            return new SystemMetricsSnapshot();
+#if UNITY_IOS && !UNITY_EDITOR
+        var snap = new SystemMetricsSnapshot
+        {
+            Timestamp            = BugsnagPerformanceUtil.GetNanoSecondsNow(),
+            ProcessCPUPercent    = bugsnag_unity_performance_process_cpu_percent(),
+            MainThreadCPUPercent = bugsnag_unity_performance_main_thread_cpu_percent(),
+            iOSMetrics           = new iOSMemoryMetrics
+            {
+                PhysicalMemoryInUse = (long)bugsnag_unity_performance_physical_memory_in_use(),
+                TotalDeviceMemory   = (long)bugsnag_unity_performance_total_device_memory()
+            }
+        };
+        return snap;
+#else
+            return null;
+#endif
         }
     }
 }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/Span.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/Span.cs
@@ -304,21 +304,21 @@ namespace BugsnagUnityPerformance
             _attributes.Remove(FPS_TARGET_KEY);
         }
 
-        internal void CalculateCPUMetrics(List<SystemMetricsSnapshot> snapshots)
+        internal void ApplyCPUMetrics(List<SystemMetricsSnapshot> snapshots)
         {
             // Timestamps
             var timestamps = snapshots.Select(s => s.Timestamp).ToArray();
-            SetAttribute(CPU_MEASURES_TIMESTAMPS_KEY, timestamps);
+            SetAttributeInternal(CPU_MEASURES_TIMESTAMPS_KEY, timestamps);
             // CPU
             var processCpu = snapshots.Select(s => Math.Round(s.ProcessCPUPercent, 2)).ToArray();
             var mainThreadCpu = snapshots.Select(s => Math.Round(s.MainThreadCPUPercent, 2)).ToArray();
 
-            SetAttribute(CPU_MEASURES_TOTAL_KEY, processCpu);
-            SetAttribute(CPU_MEASURES_MAIN_THREAD_KEY, mainThreadCpu);
-            SetAttribute(CPU_MEAN_TOTAL_KEY, Math.Round(processCpu.Average(), 2));
-            SetAttribute(CPU_MEAN_MAIN_THREAD_KEY, Math.Round(mainThreadCpu.Average(), 2));
+            SetAttributeInternal(CPU_MEASURES_TOTAL_KEY, processCpu);
+            SetAttributeInternal(CPU_MEASURES_MAIN_THREAD_KEY, mainThreadCpu);
+            SetAttributeInternal(CPU_MEAN_TOTAL_KEY, Math.Round(processCpu.Average(), 2));
+            SetAttributeInternal(CPU_MEAN_MAIN_THREAD_KEY, Math.Round(mainThreadCpu.Average(), 2));
         }
-        internal void CalculateMemoryMetrics(List<SystemMetricsSnapshot> snapshots)
+        internal void ApplyMemoryMetrics(List<SystemMetricsSnapshot> snapshots)
         {
             var timestamps = snapshots.Select(s => s.Timestamp).ToArray();
             SetAttributeInternal(MEMORY_TIMESTAMPS_KEY, timestamps);

--- a/features/cpu_metrics.feature
+++ b/features/cpu_metrics.feature
@@ -12,15 +12,15 @@ Feature: CPU Metrics
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes" is an array with 9 elements
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" boolean attribute "bugsnag.span.first_class" is true
 
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.3.key" equals "bugsnag.system.cpu_measures_timestamps"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.3.value.arrayValue.values" is an array with 5 elements
-
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.4.key" equals "bugsnag.system.cpu_measures_total"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.4.key" equals "bugsnag.system.cpu_measures_timestamps"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.4.value.arrayValue.values" is an array with 5 elements
+
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.5.key" equals "bugsnag.system.cpu_measures_total"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.5.value.arrayValue.values" is an array with 5 elements
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double array attribute "bugsnag.system.cpu_measures_total" contains valid percentages
 
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.5.key" equals "bugsnag.system.cpu_measures_main_thread"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.5.value.arrayValue.values" is an array with 5 elements
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.6.key" equals "bugsnag.system.cpu_measures_main_thread"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.6.value.arrayValue.values" is an array with 5 elements
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double array attribute "bugsnag.system.cpu_measures_main_thread" contains valid percentages
 
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double attribute "bugsnag.metrics.cpu_mean_total" is a valid percentage
@@ -36,15 +36,15 @@ Feature: CPU Metrics
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes" is an array with 9 elements
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" boolean attribute "bugsnag.span.first_class" is true
 
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.3.key" equals "bugsnag.system.cpu_measures_timestamps"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.3.value.arrayValue.values" is an array with 5 elements
-
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.4.key" equals "bugsnag.system.cpu_measures_total"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.4.key" equals "bugsnag.system.cpu_measures_timestamps"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.4.value.arrayValue.values" is an array with 5 elements
+
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.5.key" equals "bugsnag.system.cpu_measures_total"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.5.value.arrayValue.values" is an array with 5 elements
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double array attribute "bugsnag.system.cpu_measures_total" contains valid percentages
 
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.5.key" equals "bugsnag.system.cpu_measures_main_thread"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.5.value.arrayValue.values" is an array with 5 elements
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.6.key" equals "bugsnag.system.cpu_measures_main_thread"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.6.value.arrayValue.values" is an array with 5 elements
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double array attribute "bugsnag.system.cpu_measures_main_thread" contains valid percentages
 
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double attribute "bugsnag.metrics.cpu_mean_total" is a valid percentage

--- a/features/cpu_metrics.feature
+++ b/features/cpu_metrics.feature
@@ -27,6 +27,30 @@ Feature: CPU Metrics
     
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double attribute "bugsnag.system.cpu_mean_main_thread" is a valid percentage
 
+  @ios_only
+  Scenario: iOS CPU Metrics
+    When I run the game in the "CpuMetrics" state
+    And I wait for 1 span
+
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "CpuMetrics"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes" is an array with 9 elements
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" boolean attribute "bugsnag.span.first_class" is true
+
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.3.key" equals "bugsnag.system.cpu_measures_timestamps"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.3.value.arrayValue.values" is an array with 5 elements
+
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.4.key" equals "bugsnag.system.cpu_measures_total"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.4.value.arrayValue.values" is an array with 5 elements
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double array attribute "bugsnag.system.cpu_measures_total" contains valid percentages
+
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.5.key" equals "bugsnag.system.cpu_measures_main_thread"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.5.value.arrayValue.values" is an array with 5 elements
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double array attribute "bugsnag.system.cpu_measures_main_thread" contains valid percentages
+
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double attribute "bugsnag.metrics.cpu_mean_total" is a valid percentage
+    
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double attribute "bugsnag.system.cpu_mean_main_thread" is a valid percentage
+
 
   Scenario: Disable Cpu Metrics
     When I run the game in the "ConfigureCpuMetrics" state

--- a/features/memory_metrics.feature
+++ b/features/memory_metrics.feature
@@ -36,6 +36,30 @@ Feature: Memory Metrics
   * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.10.key" equals "bugsnag.system.memory.spaces.art.mean"
   * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "bugsnag.system.memory.spaces.art.mean" is greater than 0
 
+  @ios_only
+  Scenario: iOS Memory Metrics
+    When I run the game in the "MemoryMetrics" state
+    And I wait for 1 span
+
+  # Basic checks
+  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "MemoryMetrics"
+  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes" is an array with 12 elements
+  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" boolean attribute "bugsnag.span.first_class" is true
+
+  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.3.key" equals "bugsnag.system.memory.timestamps"
+  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.3.value.arrayValue.values" is an array with 5 elements
+
+  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "bugsnag.device.physical_device_memory" is greater than 0
+
+  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.5.key" equals "bugsnag.system.memory.spaces.device.size"
+  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "bugsnag.system.memory.spaces.device.size" is greater than 0
+
+  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.6.key" equals "bugsnag.system.memory.spaces.device.used"
+  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.6.value.arrayValue.values" is an array with 5 elements
+
+  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.7.key" equals "bugsnag.system.memory.spaces.device.mean"
+  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "bugsnag.system.memory.spaces.device.mean" is greater than 0
+
 
   Scenario: Disable Memory Metrics
     When I run the game in the "ConfigureMemoryMetrics" state

--- a/features/memory_metrics.feature
+++ b/features/memory_metrics.feature
@@ -13,27 +13,27 @@ Feature: Memory Metrics
   * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes" is an array with 12 elements
   * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" boolean attribute "bugsnag.span.first_class" is true
 
-  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.3.key" equals "bugsnag.system.memory.timestamps"
-  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.3.value.arrayValue.values" is an array with 5 elements
+  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.4.key" equals "bugsnag.system.memory.timestamps"
+  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.4.value.arrayValue.values" is an array with 5 elements
 
   * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "bugsnag.device.physical_device_memory" is greater than 0
 
-  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.5.key" equals "bugsnag.system.memory.spaces.device.size"
+  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.6.key" equals "bugsnag.system.memory.spaces.device.size"
   * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "bugsnag.system.memory.spaces.device.size" is greater than 0
 
-  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.6.key" equals "bugsnag.system.memory.spaces.device.used"
-  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.6.value.arrayValue.values" is an array with 5 elements
+  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.7.key" equals "bugsnag.system.memory.spaces.device.used"
+  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.7.value.arrayValue.values" is an array with 5 elements
 
-  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.7.key" equals "bugsnag.system.memory.spaces.device.mean"
+  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.8.key" equals "bugsnag.system.memory.spaces.device.mean"
   * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "bugsnag.system.memory.spaces.device.mean" is greater than 0
 
-  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.8.key" equals "bugsnag.system.memory.spaces.art.size"
+  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.9.key" equals "bugsnag.system.memory.spaces.art.size"
   * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "bugsnag.system.memory.spaces.art.size" is greater than 0
 
-  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.9.key" equals "bugsnag.system.memory.spaces.art.used"
-  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.9.value.arrayValue.values" is an array with 5 elements
+  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.10.key" equals "bugsnag.system.memory.spaces.art.used"
+  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.10.value.arrayValue.values" is an array with 5 elements
 
-  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.10.key" equals "bugsnag.system.memory.spaces.art.mean"
+  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.11.key" equals "bugsnag.system.memory.spaces.art.mean"
   * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "bugsnag.system.memory.spaces.art.mean" is greater than 0
 
   @ios_only

--- a/features/memory_metrics.feature
+++ b/features/memory_metrics.feature
@@ -43,7 +43,7 @@ Feature: Memory Metrics
 
   # Basic checks
   * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "MemoryMetrics"
-  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes" is an array with 12 elements
+  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes" is an array with 9 elements
   * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" boolean attribute "bugsnag.span.first_class" is true
 
   * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.3.key" equals "bugsnag.system.memory.timestamps"

--- a/features/memory_metrics.feature
+++ b/features/memory_metrics.feature
@@ -46,18 +46,18 @@ Feature: Memory Metrics
   * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes" is an array with 9 elements
   * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" boolean attribute "bugsnag.span.first_class" is true
 
-  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.3.key" equals "bugsnag.system.memory.timestamps"
-  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.3.value.arrayValue.values" is an array with 5 elements
+  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.4.key" equals "bugsnag.system.memory.timestamps"
+  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.4.value.arrayValue.values" is an array with 5 elements
 
   * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "bugsnag.device.physical_device_memory" is greater than 0
 
-  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.5.key" equals "bugsnag.system.memory.spaces.device.size"
+  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.6.key" equals "bugsnag.system.memory.spaces.device.size"
   * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "bugsnag.system.memory.spaces.device.size" is greater than 0
 
-  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.6.key" equals "bugsnag.system.memory.spaces.device.used"
-  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.6.value.arrayValue.values" is an array with 5 elements
+  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.7.key" equals "bugsnag.system.memory.spaces.device.used"
+  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.7.value.arrayValue.values" is an array with 5 elements
 
-  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.7.key" equals "bugsnag.system.memory.spaces.device.mean"
+  * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.8.key" equals "bugsnag.system.memory.spaces.device.mean"
   * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "bugsnag.system.memory.spaces.device.mean" is greater than 0
 
 


### PR DESCRIPTION
## Goal

Add native memory and CPU metrics for unity iOS builds.

## Changeset

- Added native iOS calls to sample memory and CPU stats, see `BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Native/iOSNative.cs` and `BugsnagPerformance/Assets/BugsnagPerformance/Plugins/iOS/BugsnagPerformanceMetrics.mm.`
- Moved span processing delay to happen after sampling to allow more time for app start spans to have metrics.

## Testing

Create iOS specific tests