### PR TITLE
Set default endpoints based on API key

### DIFF
--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
@@ -14,7 +14,7 @@ namespace BugsnagUnityPerformance
         private const string LEGACY_DEFAULT_ENDPOINT = "https://otlp.bugsnag.com/v1/traces";
         private const string DEFAULT_ENDPOINT = "https://{0}.otlp.bugsnag.com/v1/traces";
         private const string HUB_ENDPOINT = "https://{0}.insighthub.smartbear.com/v1/traces";
-        private const string HubApiPrefix = "00000";
+        private const string HUB_API_PREFIX = "00000";
 
         internal const int DEFAULT_ATTRIBUTE_STRING_VALUE_LIMIT = 1024;
         private const int MAXIMUM_ATTRIBUTE_STRING_VALUE_LIMIT = 10000;
@@ -134,7 +134,7 @@ namespace BugsnagUnityPerformance
         public string ServiceName = string.Empty;
         private bool IsHubApiKey(string apiKey)
         {
-            return !string.IsNullOrEmpty(apiKey) && apiKey.StartsWith(HubApiPrefix);
+            return !string.IsNullOrEmpty(apiKey) && apiKey.StartsWith(HUB_API_PREFIX);
         }
         public string GetEndpoint()
         {

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
@@ -13,6 +13,9 @@ namespace BugsnagUnityPerformance
 
         private const string LEGACY_DEFAULT_ENDPOINT = "https://otlp.bugsnag.com/v1/traces";
         private const string DEFAULT_ENDPOINT = "https://{0}.otlp.bugsnag.com/v1/traces";
+        private const string HUB_ENDPOINT = "https://{0}.insighthub.smartbear.com/v1/traces";
+        private const string HubApiPrefix = "00000";
+
         internal const int DEFAULT_ATTRIBUTE_STRING_VALUE_LIMIT = 1024;
         private const int MAXIMUM_ATTRIBUTE_STRING_VALUE_LIMIT = 10000;
         internal const int DEFAULT_ATTRIBUTE_ARRAY_LENGTH_LIMIT = 1000;
@@ -129,12 +132,15 @@ namespace BugsnagUnityPerformance
         internal bool IsFixedSamplingProbability => SamplingProbability >= 0;
 
         public string ServiceName = string.Empty;
-
+        private bool IsHubApiKey(string apiKey)
+        {
+            return !string.IsNullOrEmpty(apiKey) && apiKey.StartsWith(HubApiPrefix);
+        }
         public string GetEndpoint()
         {
             if (string.IsNullOrEmpty(Endpoint) || Endpoint == LEGACY_DEFAULT_ENDPOINT)
             {
-                return string.Format(DEFAULT_ENDPOINT, ApiKey);
+                return string.Format(IsHubApiKey(ApiKey) ? HUB_ENDPOINT : DEFAULT_ENDPOINT, ApiKey);
             }
             return Endpoint;
         }

--- a/BugsnagPerformance/Assets/UnitTests/ConfigurationTests.cs
+++ b/BugsnagPerformance/Assets/UnitTests/ConfigurationTests.cs
@@ -13,7 +13,10 @@ namespace Tests
     {
 
         private const string VALID_API_KEY = "227df1042bc7772c321dbde3b31a03c2";
-
+        private const string HubApiKey = "00000abcdef1234567890abcdef12345";
+        private const string LegacyDefaultEndpoint = "https://otlp.bugsnag.com/v1/traces";
+        private const string DefaultEndpointFmt = "https://{0}.otlp.bugsnag.com/v1/traces";
+        private const string HubEndpointFmt = "https://{0}.insighthub.smartbear.com/v1/traces";
         private DateTimeOffset CustomStartTime = new DateTimeOffset(1985, 1, 1, 1, 1, 1, System.TimeSpan.Zero);
         private DateTimeOffset CustomEndTime = new DateTimeOffset(1986, 1, 1, 1, 1, 1, System.TimeSpan.Zero);
         private const string LEGACY_DEFAULT_ENDPOINT = "https://otlp.bugsnag.com/v1/traces";
@@ -25,32 +28,35 @@ namespace Tests
         }
 
         [Test]
-        public void TestEndpointWhenUnset()
+        public void GetEndpoint_ReturnsDefault_WhenUnset()
         {
-            var config = new PerformanceConfiguration(VALID_API_KEY);
-            var endpoint = config.GetEndpoint();
-            var expectedEndpoint = string.Format(DEFAULT_ENDPOINT_FORMAT, VALID_API_KEY);
-            Assert.AreEqual(expectedEndpoint, endpoint);
+            var cfg = new PerformanceConfiguration(VALID_API_KEY);
+            var expected = string.Format(DefaultEndpointFmt, VALID_API_KEY);
+            Assert.That(cfg.GetEndpoint(), Is.EqualTo(expected));
         }
 
         [Test]
-        public void TestEndpointWhenSetToLegacyDefault()
+        public void GetEndpoint_IgnoresLegacyConstant_WhenExplicitlyAssigned()
         {
-            var config = new PerformanceConfiguration(VALID_API_KEY);
-            config.Endpoint = LEGACY_DEFAULT_ENDPOINT;
-            var endpoint = config.GetEndpoint();
-            var expectedEndpoint = string.Format(DEFAULT_ENDPOINT_FORMAT, VALID_API_KEY);
-            Assert.AreEqual(expectedEndpoint, endpoint);
+            var cfg = new PerformanceConfiguration(VALID_API_KEY) { Endpoint = LegacyDefaultEndpoint };
+            var expected = string.Format(DefaultEndpointFmt, VALID_API_KEY);
+            Assert.That(cfg.GetEndpoint(), Is.EqualTo(expected));
         }
 
         [Test]
-        public void TestEndpointWhenSetToCustomValue()
+        public void GetEndpoint_UsesHubDomain_WhenApiKeyStartsWith00000()
         {
-            var config = new PerformanceConfiguration(VALID_API_KEY);
-            string customEndpoint = "https://custom.endpoint.com/traces";
-            config.Endpoint = customEndpoint;
-            var endpoint = config.GetEndpoint();
-            Assert.AreEqual(customEndpoint, endpoint);
+            var cfg = new PerformanceConfiguration(HubApiKey);
+            var expected = string.Format(HubEndpointFmt, HubApiKey);
+            Assert.That(cfg.GetEndpoint(), Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void GetEndpoint_ReturnsCustom_WhenEndpointPropertySet()
+        {
+            const string custom = "https://custom.endpoint.com/traces";
+            var cfg = new PerformanceConfiguration(VALID_API_KEY) { Endpoint = custom };
+            Assert.That(cfg.GetEndpoint(), Is.EqualTo(custom));
         }
 
         [Test]

--- a/BugsnagPerformance/Assets/UnitTests/ConfigurationTests.cs
+++ b/BugsnagPerformance/Assets/UnitTests/ConfigurationTests.cs
@@ -13,14 +13,12 @@ namespace Tests
     {
 
         private const string VALID_API_KEY = "227df1042bc7772c321dbde3b31a03c2";
-        private const string HubApiKey = "00000abcdef1234567890abcdef12345";
-        private const string LegacyDefaultEndpoint = "https://otlp.bugsnag.com/v1/traces";
-        private const string DefaultEndpointFmt = "https://{0}.otlp.bugsnag.com/v1/traces";
-        private const string HubEndpointFmt = "https://{0}.insighthub.smartbear.com/v1/traces";
+        private const string HUB_API_KEY = "00000abcdef1234567890abcdef12345";
+        private const string LEGACY_DEFAULT_ENDPOINT = "https://otlp.bugsnag.com/v1/traces";
+        private const string DEFAULT_ENDPOINT = "https://{0}.otlp.bugsnag.com/v1/traces";
+        private const string HUB_ENDPOINT = "https://{0}.insighthub.smartbear.com/v1/traces";
         private DateTimeOffset CustomStartTime = new DateTimeOffset(1985, 1, 1, 1, 1, 1, System.TimeSpan.Zero);
         private DateTimeOffset CustomEndTime = new DateTimeOffset(1986, 1, 1, 1, 1, 1, System.TimeSpan.Zero);
-        private const string LEGACY_DEFAULT_ENDPOINT = "https://otlp.bugsnag.com/v1/traces";
-        private const string DEFAULT_ENDPOINT_FORMAT = "https://{0}.otlp.bugsnag.com/v1/traces";
 
         private void OnSpanEnd(Span span)
         {
@@ -31,23 +29,23 @@ namespace Tests
         public void GetEndpoint_ReturnsDefault_WhenUnset()
         {
             var cfg = new PerformanceConfiguration(VALID_API_KEY);
-            var expected = string.Format(DefaultEndpointFmt, VALID_API_KEY);
+            var expected = string.Format(DEFAULT_ENDPOINT, VALID_API_KEY);
             Assert.That(cfg.GetEndpoint(), Is.EqualTo(expected));
         }
 
         [Test]
         public void GetEndpoint_IgnoresLegacyConstant_WhenExplicitlyAssigned()
         {
-            var cfg = new PerformanceConfiguration(VALID_API_KEY) { Endpoint = LegacyDefaultEndpoint };
-            var expected = string.Format(DefaultEndpointFmt, VALID_API_KEY);
+            var cfg = new PerformanceConfiguration(VALID_API_KEY) { Endpoint = LEGACY_DEFAULT_ENDPOINT };
+            var expected = string.Format(DEFAULT_ENDPOINT, VALID_API_KEY);
             Assert.That(cfg.GetEndpoint(), Is.EqualTo(expected));
         }
 
         [Test]
         public void GetEndpoint_UsesHubDomain_WhenApiKeyStartsWith00000()
         {
-            var cfg = new PerformanceConfiguration(HubApiKey);
-            var expected = string.Format(HubEndpointFmt, HubApiKey);
+            var cfg = new PerformanceConfiguration(HUB_API_KEY);
+            var expected = string.Format(HUB_ENDPOINT, HUB_API_KEY);
             Assert.That(cfg.GetEndpoint(), Is.EqualTo(expected));
         }
 
@@ -64,7 +62,7 @@ namespace Tests
         {
             var config = new PerformanceConfiguration(null);
             var endpoint = config.GetEndpoint();
-            var expectedEndpoint = string.Format(DEFAULT_ENDPOINT_FORMAT, string.Empty);
+            var expectedEndpoint = string.Format(DEFAULT_ENDPOINT, string.Empty);
             Assert.AreEqual(expectedEndpoint, endpoint);
         }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Additions
+
+- Set default endpoints based on API key [#184](https://github.com/bugsnag/bugsnag-unity-performance/pull/184)
+
 ## v1.8.1 (2025-03-27)
 
 ### Bug Fixes


### PR DESCRIPTION
## Goal

Set default endpoints based on API key. If no endpoint is configured, payloads should be sent to `*.insighthub.smartbear.com` if the API key starts with `00000`.

## Changeset

- Refactored PerformanceConfiguration class to support hub endpoints

## Testing

Unit tested