### PR TITLE
Releases/v1.10.0

### DIFF
--- a/.buildkite/pipeline_trigger.sh
+++ b/.buildkite/pipeline_trigger.sh
@@ -3,6 +3,7 @@
 if [[ "$BUILDKITE_MESSAGE" == *"[full ci]"* ||
   "$BUILDKITE_BRANCH" == "next" ||
   "$BUILDKITE_BRANCH" == "main" ||
+  "$BUILDKITE_BRANCH" == releases/* ||
   ! -z "$FULL_SCHEDULED_BUILD" ||
   "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" == "main" ]]; then
   echo "Running full build"

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Version.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Internal/Version.cs
@@ -3,6 +3,6 @@
     internal static class Version
     {
         //TODO set this using sed or something in the release automation task
-        public const string VersionString = "1.9.0";
+        public const string VersionString = "1.10.0";
     }
 }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Models/ResourceModel.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Models/ResourceModel.cs
@@ -27,6 +27,8 @@ namespace BugsnagUnityPerformance
                 new AttributeModel("service.name", GetServiceName(config)),
                 new AttributeModel("bugsnag.app.platform", GetPlatform()),
                 new AttributeModel("bugsnag.runtime_versions.unity", Application.unityVersion),
+                new AttributeModel("os.type", GetOsType()),
+                new AttributeModel("os.name", GetOsName()),
                 new AttributeModel("device.screen_resolution.width", Screen.width),
                 new AttributeModel("device.screen_resolution.height", Screen.height)
             };
@@ -81,6 +83,30 @@ namespace BugsnagUnityPerformance
                 case RuntimePlatform.WindowsPlayer:
                 case RuntimePlatform.WindowsEditor:
                     return "Windows";
+            }
+            return string.Empty;
+        }
+
+        private string GetOsType()
+        {
+            switch (Application.platform)
+            {
+                case RuntimePlatform.IPhonePlayer:
+                    return "darwin";
+                case RuntimePlatform.Android:
+                    return "linux";
+            }
+            return string.Empty;
+        }
+
+        private string GetOsName()
+        {
+            switch (Application.platform)
+            {
+                case RuntimePlatform.IPhonePlayer:
+                    return "iOS";
+                case RuntimePlatform.Android:
+                    return "android";
             }
             return string.Empty;
         }

--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/PerformanceConfiguration.cs
@@ -21,7 +21,7 @@ namespace BugsnagUnityPerformance
 
         private const string LEGACY_DEFAULT_ENDPOINT = "https://otlp.bugsnag.com/v1/traces";
         private const string DEFAULT_ENDPOINT = "https://{0}.otlp.bugsnag.com/v1/traces";
-        private const string HUB_ENDPOINT = "https://{0}.insighthub.smartbear.com/v1/traces";
+        private const string HUB_ENDPOINT = "https://{0}.otlp.insighthub.smartbear.com/v1/traces";
         private const string HUB_API_PREFIX = "00000";
 
         internal const int DEFAULT_ATTRIBUTE_STRING_VALUE_LIMIT = 1024;

--- a/BugsnagPerformance/Assets/UnitTests/ConfigurationTests.cs
+++ b/BugsnagPerformance/Assets/UnitTests/ConfigurationTests.cs
@@ -16,7 +16,7 @@ namespace Tests
         private const string HUB_API_KEY = "00000abcdef1234567890abcdef12345";
         private const string LEGACY_DEFAULT_ENDPOINT = "https://otlp.bugsnag.com/v1/traces";
         private const string DEFAULT_ENDPOINT = "https://{0}.otlp.bugsnag.com/v1/traces";
-        private const string HUB_ENDPOINT = "https://{0}.insighthub.smartbear.com/v1/traces";
+        private const string HUB_ENDPOINT = "https://{0}.otlp.insighthub.smartbear.com/v1/traces";
         private DateTimeOffset CustomStartTime = new DateTimeOffset(1985, 1, 1, 1, 1, 1, System.TimeSpan.Zero);
         private DateTimeOffset CustomEndTime = new DateTimeOffset(1986, 1, 1, 1, 1, 1, System.TimeSpan.Zero);
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
+## TBD
+
 ## v1.9.0 (2025-05-27)
+
+### Bug Fixes
+
+- Fix issue where hub endpoint was missing .otlp. [#187](https://github.com/bugsnag/bugsnag-unity-performance/pull/187)
 
 ### Additions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## TBD
+## v1.10.0 (2025-06-03)
 
 ### Additions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 ## TBD
 
-## v1.9.0 (2025-05-27)
+### Additions
+
+- Add os.type and os.name resource attributes [#185](https://github.com/bugsnag/bugsnag-unity-performance/pull/185)
 
 ### Bug Fixes
 
 - Fix issue where hub endpoint was missing .otlp. [#187](https://github.com/bugsnag/bugsnag-unity-performance/pull/187)
+
+## v1.9.0 (2025-05-27)
 
 ### Additions
 

--- a/features/manual_spans.feature
+++ b/features/manual_spans.feature
@@ -60,8 +60,10 @@ Feature: Manual creation of spans
     * the trace payload field "resourceSpans.0.resource" string attribute "device.manufacturer" exists
     * the trace payload field "resourceSpans.0.resource" string attribute "host.arch" exists
     * the trace payload field "resourceSpans.0.resource" string attribute "bugsnag.app.version_code" exists
+    * the trace payload field "resourceSpans.0.resource" string attribute "os.name" equals "android"
+    * the trace payload field "resourceSpans.0.resource" string attribute "os.type" equals "linux"
 
- @cocoa_only
+ @ios_only
   Scenario: iOS Specific Resource Attributes
     When I run the game in the "ManualSpan" state
     And I wait for 1 span
@@ -71,6 +73,8 @@ Feature: Manual creation of spans
     * the trace payload field "resourceSpans.0.resource" string attribute "device.manufacturer" exists
     * the trace payload field "resourceSpans.0.resource" string attribute "host.arch" exists
     * the trace payload field "resourceSpans.0.resource" string attribute "bugsnag.app.bundle_version" exists
+    * the trace payload field "resourceSpans.0.resource" string attribute "os.name" equals "iOS"
+    * the trace payload field "resourceSpans.0.resource" string attribute "os.type" equals "darwin"
 
   Scenario: null span name becomes empty string
     When I run the game in the "NullSpanName" state


### PR DESCRIPTION
## v1.10.0 (2025-06-03)

### Additions

- Add os.type and os.name resource attributes [#185](https://github.com/bugsnag/bugsnag-unity-performance/pull/185)

### Bug Fixes

- Fix issue where hub endpoint was missing .otlp. [#187](https://github.com/bugsnag/bugsnag-unity-performance/pull/187)
