### PR TITLE
make csharp linter more reliable 

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,10 +12,6 @@ steps:
       UNITY_PERFORMANCE_VERSION: *2021
     commands:
       - rake code:verify
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 3
 
   - label: Run Unit Tests
     timeout_in_minutes: 5

--- a/scripts/code_format.sh
+++ b/scripts/code_format.sh
@@ -1,35 +1,107 @@
 #!/usr/bin/env bash
-set -e  
+set -Eeuo pipefail
 
-if [ -z "$UNITY_PERFORMANCE_VERSION" ]; then
-  echo "UNITY_PERFORMANCE_VERSION must be set"
+# --- Config ---
+PROJECT_DIR="BugsnagPerformance"
+SLN_PATH="$PROJECT_DIR/BugsnagPerformance.sln"
+UNITY_BIN="/Applications/Unity/Hub/Editor/${UNITY_PERFORMANCE_VERSION}/Unity.app/Contents/MacOS/Unity"
+UNITY_LOG="${PROJECT_DIR}/Library/Logs/SyncVS-$(date +%Y%m%d-%H%M%S).log"
+
+DEFAULT_CLI_ARGS=(-quit -batchmode -nographics -logFile "$UNITY_LOG")
+SYNC_METHOD="UnityEditor.SyncVS.SyncSolution"
+
+# --- Preflight ---
+if [[ -z "${UNITY_PERFORMANCE_VERSION:-}" ]]; then
+  echo "UNITY_PERFORMANCE_VERSION must be set" >&2
+  exit 1
+fi
+if [[ ! -x "$UNITY_BIN" ]]; then
+  echo "Unity not found at: $UNITY_BIN" >&2
+  exit 1
+fi
+if [[ ! -d "$PROJECT_DIR" ]]; then
+  echo "Project directory not found: $PROJECT_DIR" >&2
   exit 1
 fi
 
-UNITY_PATH="/Applications/Unity/Hub/Editor/$UNITY_PERFORMANCE_VERSION/Unity.app/Contents/MacOS"
-DEFAULT_CLI_ARGS="-quit -batchmode -nographics"
-PROJECT_PATH="BugsnagPerformance"
+echo "==> Generating solution via Unity (${UNITY_PERFORMANCE_VERSION})"
+echo "    Log: $UNITY_LOG"
 
-# Generate .sln and project files
-$UNITY_PATH/Unity $DEFAULT_CLI_ARGS -projectPath "$PROJECT_PATH" -executeMethod "UnityEditor.SyncVS.SyncSolution"
-RESULT=$?
-if [ $RESULT -ne 0 ]; then
-  exit $RESULT
+attempt_sync() {
+  "$UNITY_BIN" "${DEFAULT_CLI_ARGS[@]}" \
+    -projectPath "$PROJECT_DIR" \
+    -executeMethod "$SYNC_METHOD"
+}
+
+wait_for_solution() {
+  # Wait up to MAX_WAIT seconds for .sln and at least one .csproj
+  local MAX_WAIT=300
+  local waited=0
+  while (( waited < MAX_WAIT )); do
+    if [[ -f "$SLN_PATH" ]] && compgen -G "$PROJECT_DIR/"'*.csproj' > /dev/null; then
+      return 0
+    fi
+    sleep 2
+    (( waited+=2 ))
+  done
+  return 1
+}
+
+# --- Sync with retry ---
+SYNC_ATTEMPTS=2
+SUCCESS=0
+for attempt in $(seq 1 "$SYNC_ATTEMPTS"); do
+  echo "---- Sync attempt $attempt/$SYNC_ATTEMPTS"
+  set +e
+  attempt_sync
+  UNITY_EXIT=$?
+  set -e
+
+  if wait_for_solution; then
+    echo "    ✔ Solution generated: $SLN_PATH"
+    SUCCESS=1
+    break
+  fi
+
+  echo "    Waiting for files failed or Unity exit was $UNITY_EXIT. Retrying..."
+done
+
+# One last **forced** SyncVS after the waits (helps on cold caches)
+if [[ $SUCCESS -eq 0 ]]; then
+  echo "---- Final SyncVS invocation after wait"
+  set +e
+  attempt_sync
+  set -e
+  if wait_for_solution; then
+    echo "    ✔ Solution generated after final sync: $SLN_PATH"
+    SUCCESS=1
+  fi
 fi
 
-# Decide which dotnet format command to run based on the argument
-FORMAT_COMMAND="dotnet format"
-if [ "$1" == "--verify" ]; then
-  FORMAT_COMMAND="dotnet format --verify-no-changes"
+# --- Validate artifacts before continuing ---
+if [[ $SUCCESS -eq 0 ]]; then
+  echo "✖ Solution file not found after retries: $SLN_PATH" >&2
+  echo "---- Unity log tail ----" >&2
+  tail -n 300 "$UNITY_LOG" || true
+  exit 2
 fi
 
-# Execute dotnet format
-$FORMAT_COMMAND "$PROJECT_PATH/BugsnagPerformance.sln"
+# --- dotnet format (solution mode) ---
+FORMAT_ARGS=( --no-restore )
+if [[ "${1:-}" == "--verify" ]]; then
+  FORMAT_ARGS+=( --verify-no-changes )
+fi
+
+echo "==> Running dotnet format on solution"
+echo "    dotnet format ${FORMAT_ARGS[*]} \"$SLN_PATH\""
+set +e
+dotnet format "${FORMAT_ARGS[@]}" "$SLN_PATH"
 EXIT_CODE=$?
+set -e
 
-if [ "$EXIT_CODE" -ne 0 ]; then
-  echo "Error: Code formatting verification found issues."
+if [[ "$EXIT_CODE" -ne 0 ]]; then
+  echo "✖ Code formatting verification found issues (exit $EXIT_CODE)." >&2
   exit "$EXIT_CODE"
 fi
 
-echo "Done."
+echo "✔ Done."


### PR DESCRIPTION
This pull request improves the reliability and robustness of the code formatting script and build pipeline. The main focus is on enhancing the `scripts/code_format.sh` script to better handle Unity solution generation and code formatting, adding more robust error handling and retry logic. Additionally, a retry block is removed from the Buildkite pipeline configuration.

**Build and CI improvements:**

* Removed the automatic retry block from the `.buildkite/pipeline.yml` code verification step, so failed runs will not be retried automatically.

**Code formatting and Unity solution generation enhancements:**

* Refactored `scripts/code_format.sh` to use stricter Bash options (`set -Eeuo pipefail`) for better error detection and handling.
* Added comprehensive preflight checks for required environment variables, Unity binary presence, and project directory existence, with clear error messages.
* Implemented retry logic for Unity solution generation, including multiple sync attempts and a final forced sync, with validation that `.sln` and `.csproj` files are created before running code formatting.
* Improved reporting and error handling for code formatting verification, including clearer output and exit codes.
