### PR TITLE
fix cpu metrics flake

### DIFF
--- a/features/cpu_metrics.feature
+++ b/features/cpu_metrics.feature
@@ -13,14 +13,14 @@ Feature: CPU Metrics
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" boolean attribute "bugsnag.span.first_class" is true
 
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.4.key" equals "bugsnag.system.cpu_measures_timestamps"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.4.value.arrayValue.values" is an array with 5 elements
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.4.value.arrayValue.values" is an array with at least 5 elements
 
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.5.key" equals "bugsnag.system.cpu_measures_total"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.5.value.arrayValue.values" is an array with 5 elements
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.5.value.arrayValue.values" is an array with at least 5 elements
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double array attribute "bugsnag.system.cpu_measures_total" contains valid percentages
 
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.6.key" equals "bugsnag.system.cpu_measures_main_thread"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.6.value.arrayValue.values" is an array with 5 elements
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.6.value.arrayValue.values" is an array with at least 5 elements
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double array attribute "bugsnag.system.cpu_measures_main_thread" contains valid percentages
 
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double attribute "bugsnag.system.cpu_mean_total" is a valid percentage
@@ -37,14 +37,14 @@ Feature: CPU Metrics
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" boolean attribute "bugsnag.span.first_class" is true
 
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.4.key" equals "bugsnag.system.cpu_measures_timestamps"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.4.value.arrayValue.values" is an array with 5 elements
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.4.value.arrayValue.values" is an array with at least 5 elements
 
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.5.key" equals "bugsnag.system.cpu_measures_total"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.5.value.arrayValue.values" is an array with 5 elements
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.5.value.arrayValue.values" is an array with at least 5 elements
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double array attribute "bugsnag.system.cpu_measures_total" contains valid percentages
 
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.6.key" equals "bugsnag.system.cpu_measures_main_thread"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.6.value.arrayValue.values" is an array with 5 elements
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.attributes.6.value.arrayValue.values" is an array with at least 5 elements
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double array attribute "bugsnag.system.cpu_measures_main_thread" contains valid percentages
 
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" double attribute "bugsnag.system.cpu_mean_total" is a valid percentage

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -275,3 +275,26 @@ When('the {request_type} payload field {string} double array attribute {string} 
     check_valid_percentage(float_value, field_name, attribute_name, request_type)
   end
 end
+
+When('the {request_type} payload field {string} is an array with at least {int} elements') do |request_type, field_name, min_count|
+  list = Maze::Server.list_for(request_type)
+  array_value = Maze::Helper.read_key_path(list.current[:body], field_name)
+  
+  Maze.check.not_nil(
+    array_value, 
+    "Field '#{field_name}' not found in request type '#{request_type}'"
+  )
+  
+  Maze.check.true(
+    array_value.is_a?(Array), 
+    "Field '#{field_name}' is not an array in request type '#{request_type}', got: #{array_value.class}"
+  )
+  
+  actual_count = array_value.length
+  Maze.check.operator(
+    actual_count,
+    :>=,
+    min_count,
+    "Expected '#{field_name}' to have at least #{min_count} elements in request type '#{request_type}', but got #{actual_count}"
+  )
+end


### PR DESCRIPTION
This pull request updates the CPU metrics feature tests to be more flexible regarding the number of elements expected in certain array fields. Instead of requiring exactly 5 elements, the tests now check for at least 5 elements. Additionally, a new step definition has been added to support this behavior in the test framework.

**Test enhancements for array size flexibility:**

* Updated the CPU metrics feature scenarios in `cpu_metrics.feature` to expect arrays with at least 5 elements, rather than exactly 5, for the fields `bugsnag.system.cpu_measures_timestamps`, `bugsnag.system.cpu_measures_total`, and `bugsnag.system.cpu_measures_main_thread`. [[1]](diffhunk://#diff-ac86e5a0c06d9c2608cb97f0138b79ea514245993679283aa584ebd7969a6871L16-R23) [[2]](diffhunk://#diff-ac86e5a0c06d9c2608cb97f0138b79ea514245993679283aa584ebd7969a6871L40-R47)

**Test step definition improvements:**

* Added a new step definition to `unity_steps.rb` that checks if a payload field is an array with at least a specified number of elements, enabling the more flexible checks in the feature tests.