### PR TITLE
Preparation for using Maze Runner idempotent commands

### DIFF
--- a/.buildkite/unity.6000.full.yml
+++ b/.buildkite/unity.6000.full.yml
@@ -7,7 +7,7 @@ agents:
 steps:
   - group: ":hammer: Build Unity 6000 Test Fixtures"
     steps:
-      - label: ':macos: Build macos test fixture for Unity 2022'
+      - label: ':macos: Build macos test fixture for Unity 6000'
         timeout_in_minutes: 30
         key: build-macos-fixture-6000
         depends_on: build-artifacts

--- a/features/persistence.feature
+++ b/features/persistence.feature
@@ -11,9 +11,9 @@ Feature: Trace and state persistence
     And the trace "Bugsnag-Span-Sampling" header equals "1:3"
     And I wait for requests to persist
     And I discard the oldest trace
-    And I close the Unity app
+    And I stop the Unity app
     Then I set the HTTP status code to 200
-    And I relaunch the app
+    And I start the Unity app
     And I run the game in the "StartSDK" state
     And I wait to receive at least 3 spans
     And the trace "Bugsnag-Span-Sampling" header equals "1:3"
@@ -27,9 +27,9 @@ Feature: Trace and state persistence
     And the trace "Bugsnag-Span-Sampling" header equals "1:3"
     And I wait for requests to persist
     And I discard the oldest trace
-    And I close the Unity app
+    And I stop the Unity app
     Then I set the HTTP status code to 200
-    And I relaunch the app
+    And I start the Unity app
     And I run the game in the "MaxBatchAge" state
     And I should receive no trace
 
@@ -40,10 +40,10 @@ Feature: Trace and state persistence
     And I run the game in the "PValueUpdate" state
     And I wait to receive a sampling request
     Then I should receive no traces
-    Then I close the Unity app
+    Then I stop the Unity app
     # Block the next initial P value request so that it keeps its 0.0 P value
     And I set the HTTP status code for the next request to 404
-    And I relaunch the app
+    And I start the Unity app
     And I run the game in the "PValueUpdate" state
     Then I should receive no traces
 
@@ -54,9 +54,9 @@ Feature: Trace and state persistence
     And I run the game in the "PValueUpdate" state
     And I wait to receive a sampling request
     Then I should receive no traces
-    Then I close the Unity app
+    Then I stop the Unity app
     And I set the sampling probability for the next traces to "1"
-    And I relaunch the app
+    And I start the Unity app
     And I run the game in the "PValueUpdate" state
     And I wait to receive at least 1 span
     And the trace "Bugsnag-Span-Sampling" header equals "1:1"
@@ -70,10 +70,10 @@ Feature: Trace and state persistence
     And the trace "Bugsnag-Span-Sampling" header equals "1:1"
     And I wait for requests to persist
     And I discard the oldest trace
-    Then I close the Unity app
+    Then I stop the Unity app
     # Block the next initial P value request so that it keeps its 1.0 P value
     And I set the HTTP status code for the next request to 404
-    And I relaunch the app
+    And I start the Unity app
     And I run the game in the "PValueUpdate" state
     And I wait to receive at least 1 span
     And the trace "Bugsnag-Span-Sampling" header equals "1:1"
@@ -87,9 +87,9 @@ Feature: Trace and state persistence
     And the trace "Bugsnag-Span-Sampling" header equals "1:1"
     And I wait for requests to persist
     And I discard the oldest trace
-    Then I close the Unity app
+    Then I stop the Unity app
     And I set the sampling probability for the next traces to "0"
-    And I relaunch the app
+    And I start the Unity app
     And I run the game in the "PValueUpdate" state
     Then I should receive no traces
 

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -90,16 +90,6 @@ When('I wait for requests to persist') do
   sleep 2
 end
 
-When('I relaunch the app') do
-  next unless Maze.config.device
-  Maze::Api::Appium::AppManager.new.launch
-  sleep 3
-end
-
-When('I close the Unity app') do
-  execute_command('close_application')
-end
-
 Then("the span named {string} has a minimum duration of {int}") do |span_name,duration|
 
   spans = spans_from_request_list(Maze::Server.list_for("traces"))
@@ -297,4 +287,56 @@ When('the {request_type} payload field {string} is an array with at least {int} 
     min_count,
     "Expected '#{field_name}' to have at least #{min_count} elements in request type '#{request_type}', but got #{actual_count}"
   )
+end
+
+When('I stop the Unity app') do
+  stop_app
+end
+
+When('I start the Unity app') do
+  start_app
+end
+
+def start_app
+  platform = Maze::Helper.get_current_platform
+  case platform
+  when 'macos'
+    # Open the fixture - call executable directly rather than use open, which flakes on CI
+    command = "#{Maze.config.app}/Contents/MacOS/Mazerunner --args > /dev/null"
+    Maze::Runner.run_command(command, blocking: false)
+  when 'windows'
+    command = "#{Maze.config.app}"
+    Maze::Runner.run_command(command, blocking: false)
+  when 'android', 'ios'
+    manager = Maze::Api::Appium::AppManager.new
+    manager.activate
+  when 'switch'
+    switch_run_on_target
+  when 'browser'
+    # WebGL - do nothing
+  else
+    raise "Platform #{platform} has not been considered"
+  end
+end
+
+def stop_app
+  platform = Maze::Helper.get_current_platform
+  case platform
+  when 'macos'
+    `killall Mazerunner`
+  when 'windows'
+    # This assumes Maze Runner is being run under WSL
+    process_name = File.basename(Maze.config.app)
+    `/mnt/c/Windows/system32/taskkill.exe /F /IM #{process_name}`
+  when 'android', 'ios'
+    manager = Maze::Api::Appium::AppManager.new
+    manager.terminate
+  when 'switch'
+    # Terminate the app
+    Maze::Runner.run_command('ControlTarget.exe terminate')
+  when 'browser'
+    # WebGL - do nothing
+  else
+    raise "Platform #{platform} has not been considered"
+  end
 end

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -15,37 +15,16 @@ end
 
 When('I clear the Bugsnag cache') do
   case Maze::Helper.get_current_platform
-  when 'macos', 'webgl'
-    # Call executable directly rather than use open, which flakes on CI
-    log = File.join(Dir.pwd, 'clear_cache.log')
-    command = "#{Maze.config.app}/Contents/MacOS/Mazerunner --args -logfile #{log} > /dev/null"
-    Maze::Runner.run_command(command, blocking: false)
-    execute_command('clear_cache')
-
-  when 'windows'
-    win_log = File.join(Dir.pwd, 'clear_cache.log')
-    command = "#{Maze.config.app} --args -logfile #{win_log}"
-    Maze::Runner.run_command(command, blocking: false)
-    execute_command('clear_cache')
-
-  when 'android', 'ios'
+  when 'macos', 'windows', 'android', 'ios', 'switch'
     execute_command('clear_cache')
   when 'browser'
     url = "http://localhost:#{Maze.config.port}/docs/index.html"
     $logger.debug "Navigating to URL: #{url}"
     step("I navigate to the URL \"#{url}\"")
     execute_command('clear_cache')
-
-  when 'switch'
-    switch_run_on_target
-    execute_command('clear_cache')
-
   else
     raise "Platform #{platform} has not been considered"
   end
-
-  sleep 2
-
 end
 
 When('I run the game in the {string} state') do |state|

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,15 +1,5 @@
 require 'fileutils'
 
-Before('@skip_unity_2018') do |_scenario|
-  if ENV['UNITY_VERSION']
-    unity_version = ENV['UNITY_VERSION'][0..3].to_i
-    if unity_version == 2018
-      skip_this_scenario('Skipping scenario on Unity 2018')
-    end
-  end
-end
-
-
 Before('@skip_webgl') do |_scenario|
   skip_this_scenario('Skipping scenario') unless Maze.config.browser.nil?
 end
@@ -126,23 +116,15 @@ Maze.hooks.before do
     $logger.info 'Killing defaults service'
     Maze::Runner.run_command("killall -u #{ENV['USER']} cfprefsd")
   end
+
+  platform = Maze::Helper.get_current_platform
+  start_app unless platform in ['android', 'ios'] # Maze Runner will handle mobile platforms
 end
 
 After do |scenario|
   next if scenario.status == :skipped
 
-  case Maze::Helper.get_current_platform
-  when 'macos'
-    `killall Mazerunner`
-  when 'windows'
-    Maze::Runner.run_command("/mnt/c/Windows/system32/taskkill.exe /IM mazerunner_windows.exe || exit 0")  
-    Maze::Runner.run_command("/mnt/c/Windows/system32/taskkill.exe /IM mazerunner_windows_dev.exe || exit 0")  
-  when 'webgl'
-    execute_command('close_application')
-  when 'switch'
-    # Terminate the app
-    Maze::Runner.run_command('ControlTarget.exe terminate')
-  end
+  stop_app
 end
 
 AfterAll do


### PR DESCRIPTION
## Goal

Makes some initial preparations for using Maze Runner idempotent commands in e2e tests by changing how the lifecycle of the test fixtures are managed.

## Design

For macOS and Windows the test fixture will be opened at the start of each fixture and closed at the end.  If a stop or start is needed in the middle of a scenario then this is now performed using an explicit Cucumber step, instead of being the by-product of a step to issue a command to the fixture - which can cause multiple instances to run and for tests to flake.

## Changeset

Light refactoring to support the above change.

## Testing

Covered by a full CI run.