### PR TITLE
Use Maze Runner idempotent commands in e2e tests

### DIFF
--- a/features/fixtures/mazerunner/Assets/Scripts/Main.cs
+++ b/features/fixtures/mazerunner/Assets/Scripts/Main.cs
@@ -10,6 +10,7 @@ using TMPro;
 public class Command
 {
     public string action;
+    public string uuid;
     public string scenarioName;
 }
 
@@ -33,6 +34,8 @@ public class Main : MonoBehaviour
 
     private const string API_KEY = "a35a2a72bd230ac0aa0f52715bbdc6aa";
     private string _fixtureConfigFileName = "/fixture_config.json";
+    private string _commandUuidFileName = "/command_uuid.txt";
+    private static string LastCommandUuid;
     public static string MazeHost;
 
     public ScenarioRunner ScenarioRunner;
@@ -45,10 +48,34 @@ public class Main : MonoBehaviour
     public IEnumerator Start()
     {
         Log("Maze Runner app started");
+        GetLastCommandUuid();
 
         yield return GetFixtureConfig();
 
         InvokeRepeating("DoRunNextMazeCommand", 0, 1);
+    }
+
+    private void GetLastCommandUuid()
+    {
+        var uuidFilePath = Application.persistentDataPath + _commandUuidFileName;
+        if (File.Exists(uuidFilePath))
+        {
+            LastCommandUuid = File.ReadAllText(uuidFilePath);
+        }
+        else
+        {
+            LastCommandUuid = "";
+        }
+        Log("Last command UUID is: " + LastCommandUuid);
+    }
+
+    private void SetLastCommandUuid(String uuid) 
+    {
+        Log("Setting last command UUID: " + uuid);
+        var uuidFilePath = Application.persistentDataPath + _commandUuidFileName;
+        File.WriteAllText(uuidFilePath, uuid);
+        LastCommandUuid = uuid;
+        Log("Command UUID is now: " + LastCommandUuid);
     }
 
     private IEnumerator GetFixtureConfig()
@@ -73,7 +100,7 @@ public class Main : MonoBehaviour
                 {
                     Log("Mazerunner no fixture config found at path: " + configPath);
                     numTries++;
-                    if(numTries == timeOut)
+                    if (numTries == timeOut)
                     {
                         Log("Timedout looking for config file!");
                     }
@@ -105,58 +132,52 @@ public class Main : MonoBehaviour
 
     IEnumerator RunNextMazeCommand()
     {
-        var url = MazeHost + "/command";
-        Log("Trying to get next mazerunner command with url: " + url);
+        var url = MazeHost + "/idem-command?after=" + LastCommandUuid;
+        Log("Requesting Maze  Runner command from: " + url);
         using (UnityWebRequest request = UnityWebRequest.Get(url))
         {
             yield return request.SendWebRequest();
-#if UNITY_2020_1_OR_NEWER
             var result = request != null && request.result == UnityWebRequest.Result.Success;
-#else
-            var result = request != null &&
-                !request.isHttpError &&
-                !request.isNetworkError;
-#endif
 
             if (result)
             {
                 var response = request.downloadHandler?.text;
-                if (response == null || response == "null" || response == "No commands to provide" || response.Contains("noop"))
+                if (response == null || response == "null")
                 {
-
+                    Log("No Maze Runner command to process at present");
                 }
                 else
                 {
                     var command = JsonUtility.FromJson<Command>(response);
                     if (command != null)
                     {
-                        Log("Got Action: " + command.action + " and scenario: " + command.scenarioName);
-                        if ("clear_cache".Equals(command.action))
+                        Log("Received Maze Runner command:\n" + response);
+
+                        switch(command.action)
                         {
-                            ClearUnityCache();
-                        }
-                        else if ("run_scenario".Equals(command.action))
-                        {
-                            ScenarioRunner.RunScenario(command.scenarioName, API_KEY, MazeHost);
-                        }
-                        else if ("close_application".Equals(command.action))
-                        {
-                            CloseFixture();
+                            case "noop":
+                                break;
+                            case "reset_uuid":
+                                SetLastCommandUuid("");
+                                break;
+                            case "clear_cache":
+                                ClearUnityCache();
+                                SetLastCommandUuid(command.uuid);
+                                break;
+                            case "run_scenario":
+                                SetLastCommandUuid(command.uuid);
+                                ScenarioRunner.RunScenario(command.scenarioName, API_KEY, MazeHost);
+                                break;
                         }
                     }
                 }
             }
             else
             {
-                Log("Getting next mazerunner command Failed: " + request.error);
+                Log("Getting next Maze Runner command failed: " + request.error);
 
             }
         }
-    }
-
-    private void CloseFixture()
-    {
-        Application.Quit();
     }
 
     private void ClearUnityCache()
@@ -172,11 +193,6 @@ public class Main : MonoBehaviour
         if (Application.platform == RuntimePlatform.IPhonePlayer)
         {
             ClearIOSData();
-        }
-        if (Application.platform != RuntimePlatform.Android &&
-            Application.platform != RuntimePlatform.IPhonePlayer)
-        {
-            Invoke("CloseFixture", 0.25f);
         }
     }
 
@@ -197,8 +213,4 @@ public class Main : MonoBehaviour
         catch { }
 
     }
-
 }
-
-
-

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -6,11 +6,6 @@ def execute_command(action, scenario_name = '')
     scenarioName: scenario_name
   }
   Maze::Server.commands.add command
-
-  # Ensure fixture has read the command
-  count = 300
-  sleep 0.1 until Maze::Server.commands.remaining.empty? || (count -= 1) < 1
-  raise 'Test fixture did not GET /command' unless Maze::Server.commands.remaining.empty?
 end
 
 When('I clear the Bugsnag cache') do
@@ -30,36 +25,14 @@ end
 When('I run the game in the {string} state') do |state|
   platform = Maze::Helper.get_current_platform
   case platform
-  when 'macos'
-    # Call executable directly rather than use open, which flakes on CI
-    log = File.join(Dir.pwd, "#{state}-mazerunner.log")
-    command = "#{Maze.config.app}/Contents/MacOS/Mazerunner --args -logfile #{log} > /dev/null"
-    Maze::Runner.run_command(command, blocking: false)
-
+  when 'macos','android', 'ios', 'switch', 'windows'
     execute_command('run_scenario', state)
-
-  when 'windows'
-    win_log = File.join(Dir.pwd, "#{state}-mazerunner.log")
-    command = "#{Maze.config.app} --args -logfile #{win_log}"
-    Maze::Runner.run_command(command, blocking: false)
-
-    execute_command('run_scenario', state)
-
-  when 'android', 'ios'
-    execute_command('run_scenario', state)
-
   when 'browser'
     # WebGL in a browser
     url = "http://localhost:#{Maze.config.port}/docs/index.html"
     $logger.debug "Navigating to URL: #{url}"
     step("I navigate to the URL \"#{url}\"")
     execute_command('run_scenario', state)
-
-  when 'switch'
-
-    switch_run_on_target
-    execute_command('run_scenario', state)
-
   else
     raise "Platform #{platform} has not been considered"
   end


### PR DESCRIPTION
## Goal

Convert the e2e tests to use idempotent Maze Runner commands, together with various other stability improvements.

## Design

The idempotent command pattern works by passing the UUID of the last successfully processed command when making a command for the next.  This means the fixture needs to write the the UUID to disk once received so that it can be read after restarting the app.

## Changeset

- Test fixture now uses the `/idem-command` endpoint, passing the last known UUID.
- Mechanism added to persist the UUID of the last command processed, as well as reset it when instructed to by Maze Runner.

## Testing

Covered by a full CI run.