### PR TITLE
Appium version change and added app package in yml files

### DIFF
--- a/.buildkite/unity.2021.full.yml
+++ b/.buildkite/unity.2021.full.yml
@@ -224,9 +224,10 @@ steps:
             service-ports: true
             command:
               - '--app=/app/features/fixtures/mazerunner/mazerunner-dev_2021.apk'
+              - '--app-package=com.bugsnag.fixtures.unity.performance.android'
               - '--farm=bb'
               - '--device=ANDROID_9|ANDROID_10|ANDROID_11|ANDROID_12|ANDROID_13'
-              - '--appium-version=1.22'
+              - '--appium-version=2.19'
               - '--no-tunnel'
               - '--aws-public-ip'
               - '--fail-fast'

--- a/.buildkite/unity.2021.yml
+++ b/.buildkite/unity.2021.yml
@@ -226,9 +226,10 @@ steps:
             service-ports: true
             command:
               - '--app=/app/features/fixtures/mazerunner/mazerunner_2021.apk'
+              - '--app-package=com.bugsnag.fixtures.unity.performance.android'
               - '--farm=bb'
               - '--device=ANDROID_9|ANDROID_10|ANDROID_11|ANDROID_12|ANDROID_13'
-              - '--appium-version=1.22'
+              - '--appium-version=2.19'
               - '--no-tunnel'
               - '--aws-public-ip'
               - '--fail-fast'

--- a/.buildkite/unity.2022.full.yml
+++ b/.buildkite/unity.2022.full.yml
@@ -183,9 +183,10 @@ steps:
             service-ports: true
             command:
               - '--app=/app/features/fixtures/mazerunner/mazerunner_2022.apk'
+              - '--app-package=com.bugsnag.fixtures.unity.performance.android'
               - '--farm=bb'
               - '--device=ANDROID_9|ANDROID_10|ANDROID_11|ANDROID_12|ANDROID_13'
-              - '--appium-version=1.22'
+              - '--appium-version=2.19'
               - '--no-tunnel'
               - '--aws-public-ip'
               - '--fail-fast'

--- a/.buildkite/unity.6000.full.yml
+++ b/.buildkite/unity.6000.full.yml
@@ -183,9 +183,10 @@ steps:
             service-ports: true
             command:
               - '--app=/app/features/fixtures/mazerunner/mazerunner_6000.apk'
+              - '--app-package=com.bugsnag.fixtures.unity.performance.android'
               - '--farm=bb'
               - '--device=ANDROID_9|ANDROID_10|ANDROID_11|ANDROID_12|ANDROID_13'
-              - '--appium-version=1.22'
+              - '--appium-version=2.19'
               - '--no-tunnel'
               - '--aws-public-ip'
               - '--fail-fast'


### PR DESCRIPTION
Goal
Bumped --appium-version from 1.22 to 2.19 in the Unity Performance Android Buildkite pipelines.
 
Design
Earlier pipeline was using appium version 1.22 so we have changed appium version 2.19 commonly.
 
Changeset
Changed Pipeline.yml files to update version of appium from 1.22 to 2.19
Update app package in respective yml Files.
 
Testing
Yes, We have tested manual and automated maze runner test cases BB.