### PR TITLE
Align HTTP content-length attrs with OTel semantic conventions

### DIFF
--- a/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/Span.cs
+++ b/BugsnagPerformance/Assets/BugsnagPerformance/Scripts/Public/Span.cs
@@ -122,12 +122,12 @@ namespace BugsnagUnityPerformance
 
             if (request.uploadHandler != null && request.uploadHandler.data != null)
             {
-                SetAttributeInternal("http.request_content_length", request.uploadHandler.data.Length);
+                SetAttributeInternal("http.request.header.content-length", request.uploadHandler.data.Length);
             }
 
             if (request.downloadHandler != null && request.downloadHandler.data != null)
             {
-                SetAttributeInternal("http.response_content_length", request.downloadHandler.data.Length);
+                SetAttributeInternal("http.response.header.content-length", request.downloadHandler.data.Length);
             }
             _onSpanEnd(this);
         }
@@ -153,12 +153,12 @@ namespace BugsnagUnityPerformance
 
             if (requestContentLength > -1)
             {
-                SetAttributeInternal("http.request_content_length", requestContentLength);
+                SetAttributeInternal("http.request.header.content-length", requestContentLength);
             }
 
             if (responseContentLength > -1)
             {
-                SetAttributeInternal("http.response_content_length", responseContentLength);
+                SetAttributeInternal("http.response.header.content-length", responseContentLength);
             }
             _onSpanEnd(this);
         }

--- a/BugsnagPerformance/Assets/UnitTests/SpanTests.cs
+++ b/BugsnagPerformance/Assets/UnitTests/SpanTests.cs
@@ -84,8 +84,8 @@ namespace Tests
 
             var attrs = _span.GetAttributes();
             Assert.AreEqual(status, attrs["http.status_code"]);
-            Assert.AreEqual(reqLen, attrs["http.request_content_length"]);
-            Assert.AreEqual(resLen, attrs["http.response_content_length"]);
+            Assert.AreEqual(reqLen, attrs["http.request.header.content-length"]);
+            Assert.AreEqual(resLen, attrs["http.response.header.content-length"]);
         }
 
         [Test]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Misc
 
 - Amend secondary instance URL to bugsnag.smartbear.com [#207](https://github.com/bugsnag/bugsnag-unity-performance/pull/207)
+- Align HTTP content-length attrs with OTel semantic conventions [#217](https://github.com/bugsnag/bugsnag-unity-performance/pull/217)
 
 ## v1.11.0 (2025-09-03)
 

--- a/features/network_spans.feature
+++ b/features/network_spans.feature
@@ -24,7 +24,7 @@ Feature: Network Spans
 
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.status_code" is greater than 0
 
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response_content_length" is greater than 0
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response.header.content-length" is greater than 0
 
   # This test sends 2 requests, 1 fails and one succeeds, so we should only get 1
   Scenario: Get Fail
@@ -46,7 +46,7 @@ Feature: Network Spans
 
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.status_code" is greater than 0
 
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response_content_length" is greater than 0
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response.header.content-length" is greater than 0
 
   Scenario: Post Success
     When I run the game in the "NetworkPostSuccess" state
@@ -67,9 +67,9 @@ Feature: Network Spans
 
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.status_code" is greater than 0
 
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response_content_length" is greater than 0
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response.header.content-length" is greater than 0
 
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response_content_length" is greater than 0
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response.header.content-length" is greater than 0
 
   # This test sends 2 requests, 1 fails and one succeeds, so we should only get 1
   Scenario: Post Fail
@@ -91,9 +91,9 @@ Feature: Network Spans
 
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.status_code" is greater than 0
 
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response_content_length" is greater than 0
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response.header.content-length" is greater than 0
 
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response_content_length" is greater than 0
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response.header.content-length" is greater than 0
 
   Scenario: Edit url in callback
     When I run the game in the "NetworkCallbackUrlEdit" state
@@ -114,9 +114,9 @@ Feature: Network Spans
 
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.status_code" is greater than 0
 
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response_content_length" is greater than 0
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response.header.content-length" is greater than 0
 
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response_content_length" is greater than 0
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response.header.content-length" is greater than 0
 
 #this test sends 2 requests, we should only get 1 as the first will have a null url in the callback
   Scenario: Set url null in callback
@@ -138,9 +138,9 @@ Feature: Network Spans
 
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.status_code" is greater than 0
 
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response_content_length" is greater than 0
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response.header.content-length" is greater than 0
 
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response_content_length" is greater than 0
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response.header.content-length" is greater than 0
 
   Scenario: Manual Network Span
     When I run the game in the "ManualNetworkSpan" state
@@ -163,9 +163,9 @@ Feature: Network Spans
 
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.status_code" is greater than 0
 
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.request_content_length" is greater than 0
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.request.header.content-length" is greater than 0
 
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response_content_length" is greater than 0
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response.header.content-length" is greater than 0
 
   Scenario: Trace parent header smoke test
     When I run the game in the "TraceParentHeaderSmokeTest" state


### PR DESCRIPTION
## Goal

Align our network span attributes with OpenTelemetry HTTP semantic conventions.

## Design

Specifically replace below mention attributes:
http.request_content_length -> http.request.header.content-length 
http.response_content_length -> http.response.header.content-length 

## Changeset

Replace attributes in [Span.cs], [SpanTests.cs], [network_spans.feature]

## Testing

Did manual testing by build/import UPM package into fixtures and produce the app